### PR TITLE
MNT: Add .gitattributes from best practices guide

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+*.tsproj    text eol=crlf
+*.plcproj   text eol=crlf
+*.tmc       text eol=crlf
+*.xti       text eol=crlf
+*.TcTTO     text eol=crlf
+*.TcPOU     text eol=crlf
+*.TcDUT     text eol=crlf
+*.TcGVL     text eol=crlf
+*.TcVis     text eol=crlf
+*.TcVMO     text eol=crlf
+*.TcGTLO    text eol=crlf

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 _Boot
 _Libraries
 _CompileInfo
-*.sln
 *.suo
 *~
 *.tpy


### PR DESCRIPTION
Remove .sln from gitignore, as it's the Visual Studio solution and is also currently in the repo.