### PR TITLE
ENH: Add a bunch of utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ _CompileInfo
 *.~u
 *.tmcRefac
 *.swp
+*.dbg

--- a/LCLSGeneral/LCLSGeneral/GVLs/DefaultGlobals.TcGVL
+++ b/LCLSGeneral/LCLSGeneral/GVLs/DefaultGlobals.TcGVL
@@ -5,6 +5,7 @@
 VAR_GLOBAL
 	
 	stSys	:	ST_System; //Included for you
+	fTimeStamp: LREAL;
 END_VAR]]></Declaration>
   </GVL>
 </TcPlcObject>

--- a/LCLSGeneral/LCLSGeneral/LCLSGeneral.plcproj
+++ b/LCLSGeneral/LCLSGeneral/LCLSGeneral.plcproj
@@ -37,6 +37,8 @@
     <Folder Include="POUs\Functions" />
     <Folder Include="POUs\Logger" />
     <Folder Include="POUs\Logger\DUTs" />
+    <Folder Include="POUs\Data" />
+    <Folder Include="POUs\Hardware" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Data types\Misc\ST_EcDevice.TcDUT">
@@ -52,13 +54,37 @@
       <SubType>Code</SubType>
       <LinkAlways>true</LinkAlways>
     </Compile>
+    <Compile Include="POUs\Data\FB_DataBuffer.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="POUs\Data\FB_LREALBuffer.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="POUs\Data\FB_TimestampBuffer.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="POUs\Functions\FB_EcatDiag.TcPOU">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="POUs\Functions\FB_Index.TcPOU">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="POUs\Functions\FB_UnixTimestamp.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="POUs\Functions\FB_XKoyoPLCModbus.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="POUs\Hardware\FB_AnalogInput.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="POUs\Hardware\FB_AnalogOutput.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="POUs\Hardware\FB_EL6_Com.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="POUs\Hardware\FB_ThermoCouple.TcPOU">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="POUs\Logger\FB_Logger.TcPOU">

--- a/LCLSGeneral/LCLSGeneral/POUs/Data/FB_DataBuffer.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Data/FB_DataBuffer.TcPOU
@@ -1,0 +1,56 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.12">
+  <POU Name="FB_DataBuffer" Id="{663bb4ee-ee74-4dfb-9a41-308201d6b012}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_DataBuffer
+(*
+	Function Block to accumulate data into an array.
+	
+	Requires the user to supply pointers to two arrays:
+	1. A partial buffer that we will slowly fill one value at a time
+	2. An output buffer that will only update when the partial buffer is full
+	
+	Take great care of the following, or else your program will likely crash:
+	1. The input type and array types must match
+	2. The provided element count must be accurate and match both arrays
+	
+	As this function block as no way of checking that you did this correctly.
+*)
+VAR_INPUT
+	// Whether or not to accumulate on this cycle
+	bExecute: BOOL;
+	// The value to accumulate
+	aInput: ANY;
+	// Number of values in the output array
+	iElemCount: UDINT;
+	// Address of the rolling buffer to be filled every cycle
+	pPartialAdr: PVOID;
+	// Address of the output buffer to be filled when the rolling buffer is full
+	pOutputAdr: PVOID;
+END_VAR
+VAR
+	bInit: BOOL := FALSE;
+	iInputSize: UINT;
+	iArrayIndex: UDINT := 0;
+END_VAR]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[IF NOT bInit THEN
+	bInit := TRUE;
+	iInputSize := SIZEOF(aInput);
+END_IF
+IF bExecute THEN
+	MEMCPY(
+		destAddr := pPartialAdr + iArrayIndex*SIZEOF(aInput),
+		srcAddr := ADR(aInput),
+		n := SIZEOF(aInput));
+	iArrayIndex := iArrayIndex + 1;
+	IF iArrayIndex >= iElemCount THEN
+		MEMCPY(
+			destAddr := pOutputAdr,
+			srcAddr := pPartialAdr,
+			n := iElemCount*SIZEOF(aInput));
+		iArrayIndex := 0;
+	END_IF
+END_IF]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/LCLSGeneral/LCLSGeneral/POUs/Data/FB_LREALBuffer.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Data/FB_LREALBuffer.TcPOU
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.12">
+  <POU Name="FB_LREALBuffer" Id="{bbdb5874-82a3-4838-8bc3-8b225e25cc46}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_LREALBuffer
+(* An example use of FB_DataBuffer for the likely most-common use case. *)
+VAR_INPUT
+	bExecute: BOOL;
+	fInput: LREAL;
+END_VAR
+VAR_OUTPUT
+	arrOutput: ARRAY [1..1000] OF LREAL;
+END_VAR
+VAR
+	arrPartial: ARRAY [1..1000] OF LREAL;
+	fbDataBuffer: FB_DataBuffer;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[fbDataBuffer(
+	bExecute := bExecute,
+	aInput := fInput,
+	iElemCount := 1000,
+	pPartialAdr := ADR(arrPartial),
+	pOutputAdr := ADR(arrOutput));]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/LCLSGeneral/LCLSGeneral/POUs/Data/FB_TimestampBuffer.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Data/FB_TimestampBuffer.TcPOU
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.12">
+  <POU Name="FB_TimestampBuffer" Id="{b2db97ec-7312-4822-a3b4-76ec1968b59f}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_TimestampBuffer
+(* A Companion to FB_LREALBuffer that accumulates timestamps *)
+VAR_INPUT
+	bExecute: BOOL;
+END_VAR
+VAR_OUTPUT
+	arrOutput: ARRAY [1..1000] OF LREAL;
+END_VAR
+VAR
+	fbUnixTime: FB_UnixTimestamp;
+	fbLREALBuffer: FB_LREALBuffer;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[fbUnixTime(
+	bExecute := bExecute,
+	fTime => fbLREALBuffer.fInput);
+fbLREALBuffer(
+	bExecute := bExecute,
+	arrOutput => arrOutput);]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/LCLSGeneral/LCLSGeneral/POUs/Functions/FB_UnixTimeStamp.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Functions/FB_UnixTimeStamp.TcPOU
@@ -1,0 +1,41 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.12">
+  <POU Name="FB_UnixTimeStamp" Id="{74adc114-3015-429e-b699-b551ce54d443}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_UnixTimeStamp
+(*
+	Get the unix timestamp equivalent of the PLC's time
+	Largely stolen from stack overflow
+*)
+VAR_INPUT
+	bExecute: BOOL;
+END_VAR
+VAR_OUTPUT
+	iSeconds: ULINT;
+	iMilliseconds: ULINT;
+	fTime: LREAL;
+END_VAR
+VAR
+	bInit: BOOL;
+	fbLocalTime: FB_LocalSystemTime;
+	fbGetTimeZone: FB_GetTimeZoneInformation;
+	fbTimeConv: FB_TzSpecificLocalTimeToFileTime;
+	fileTime: T_FILETIME;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[IF NOT bInit THEN
+	bInit := TRUE;
+	fbGetTimeZone(bExecute:=TRUE, tzInfo => fbTimeConv.tzInfo);
+END_IF
+IF bExecute THEN
+	fbLocalTime(bEnable := TRUE, dwCycle := 1);
+	fbTimeConv(
+		in := SYSTEMTIME_TO_FILETIME(fbLocalTime.systemTime),
+		out => fileTime);
+	iSeconds := (SHL(DWORD_TO_ULINT(fileTime.dwHighDateTime), 32) + DWORD_TO_ULINT(fileTime.dwLowDateTime)) / 10000000 - 11644473600;
+	iMilliseconds := (SHL(DWORD_TO_ULINT(fileTime.dwHighDateTime), 32) + DWORD_TO_ULINT(fileTime.dwLowDateTime)) / 10000 - 11644473600000;
+	fTime := UINT_TO_LREAL(iSeconds) + UINT_TO_LREAL(iMilliseconds)/1000;
+END_IF]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/LCLSGeneral/LCLSGeneral/POUs/Functions/FB_UnixTimeStampGlobal.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Functions/FB_UnixTimeStampGlobal.TcPOU
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.12">
+  <POU Name="FB_UnixTimeStampGlobal" Id="{626742ce-ebb0-42d8-8b96-83167f2ea362}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_UnixTimeStampGlobal
+(* Runs FB_UnixTimeStamp and stuffs the result into this library's GVL *)
+VAR_INPUT
+	bExecute: BOOL;
+END_VAR
+VAR_OUTPUT
+END_VAR
+VAR
+	fbTimeStamp: FB_UnixTimeStamp;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[fbTimeStamp(
+	bExecute := bExecute,
+	fTime => DefaultGlobals.fTimeStamp);]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/LCLSGeneral/LCLSGeneral/POUs/Hardware/FB_AnalogInput.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Hardware/FB_AnalogInput.TcPOU
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.12">
+  <POU Name="FB_AnalogInput" Id="{c3bf2f11-e399-406d-ba95-ae8960e90a27}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_AnalogInput
+(* Converts the integer from an analog input terminal to a real unit value (e.g., volts) *)
+VAR_INPUT
+	// Connect this input to the terminal
+	iRaw AT %I*: INT;
+	// The number of bits correlated with the terminal's max output
+	iTermBits: UINT;
+	// The fReal value correlated with the terminal's max output
+	fTermMax: LREAL;
+	// The fReal value correlated with the terminal's min output
+	fTermMin: LREAL;
+END_VAR
+VAR_OUTPUT
+	// The real value read from the output
+	fReal: LREAL;
+END_VAR
+VAR
+	fScale: LREAL;
+END_VAR]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[IF fScale = 0 AND fTermMax > fTermMin THEN
+	fScale := (EXPT(2, iTermBits) - 1) / (fTermMax - fTermMin);
+END_IF
+IF fScale + fTermMin <> 0 THEN
+	fReal := iRaw / fScale + fTermMin;
+END_IF]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/LCLSGeneral/LCLSGeneral/POUs/Hardware/FB_AnalogOutput.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Hardware/FB_AnalogOutput.TcPOU
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.12">
+  <POU Name="FB_AnalogOutput" Id="{d5385a96-e050-4c15-80d1-455e7d2a0d81}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_AnalogOutput
+(* Converts a real unit value (e.g., volts) to the integer needed for an analog output terminal. *)
+VAR_INPUT
+	// The real value to send to the output
+	fReal: LREAL;
+	// The maximum allowed real value for the connected hardware
+	fSafeMax: LREAL;
+	// The minimum allowed real value for the connected hardware
+	fSafeMin: LREAL;
+	// The number of bits correlated with the terminal's max output
+	iTermBits: UINT;
+	// The fReal value correlated with the terminal's max output
+	fTermMax: LREAL;
+	// The fReal value correlated with the terminal's min output
+	fTermMin: LREAL;
+END_VAR
+VAR_OUTPUT
+	// Connect this output to the terminal
+	iRaw AT %Q*: INT;
+END_VAR
+VAR
+	fScale: LREAL;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[// Set the scaling from real to raw
+IF fScale = 0 AND fTermMax > fTermMin THEN
+	fScale := (EXPT(2, iTermBits) - 1) / (fTermMax - fTermMin);
+END_IF
+
+// Adjust real value to be within the limits
+fReal := MIN(fReal, fSafeMax, fTermMax);
+fReal := MAX(fReal, fSafeMin, fTermMin);
+
+// Scale the output accordingly
+iRaw := LREAL_TO_INT((fReal - fTermMin) * fScale);]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/LCLSGeneral/LCLSGeneral/POUs/Hardware/FB_EL6_Com.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Hardware/FB_EL6_Com.TcPOU
@@ -1,0 +1,177 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.12">
+  <POU Name="FB_EL6_Com" Id="{b4ce63ed-a08f-4c98-b824-d65c9e8a72f4}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_EL6_Com
+(*
+	Communicate with a serial device connected to an EL6XXX
+	May contain assumptions about the device we wrote it for, potentially will need to be adjusted
+*)
+VAR_INPUT
+	{attribute 'pytmc' := '
+		pv: CMD
+		io: io
+	'}
+	sCmd: STRING;
+	
+	{attribute 'pytmc' := '
+		pv: SEND
+		io: io
+	'}
+	bSend: BOOL;
+	
+	sSendPrefix: STRING;
+	sSendSuffix: STRING;
+	sRecvPrefix: STRING;
+	sRecvSuffix: STRING;
+	tTimeout: TIME := T#1S;
+END_VAR
+VAR_IN_OUT
+	stIn_EL6: EL6inData22B;
+	stOut_EL6: EL6outData22B;
+END_VAR
+VAR_OUTPUT
+	{attribute 'pytmc' := '
+		pv: RESP
+		io: input
+	'}
+	sResponse: STRING;
+	
+	{attribute 'pytmc' := '
+		pv: DONE
+		io: input
+	'}
+	bDone: BOOL;
+	
+	{attribute 'pytmc' := '
+		pv: ERR:SER
+		io: input
+	'}
+	eSerialLineErrorID: ComError_t;
+	
+	{attribute 'pytmc' := '
+		pv: ERR:SEND
+		io: input
+	'}
+	eSendErrorID: ComError_t;
+	
+	{attribute 'pytmc' := '
+		pv: ERR:RECV
+		io: input
+	'}
+	eRecvErrorID: ComError_t;
+END_VAR
+VAR
+	// Communication Buffers
+	TxBuffer: ComBuffer;
+	RxBuffer: ComBuffer;
+	fbClearComBuffer: ClearComBuffer;
+	
+	// Parameters for PLC -> EL6
+	fbEL6Ctrl: SerialLineControl;
+	bEL6CtrlError: BOOL;
+	eEL6CtrlErrorID: ComError_t;
+	
+	// Parameters for EL6 -> Serial Device
+	fbSend: SendString;
+	bSendBusy: BOOL;
+	eLastSendErrorID: ComError_t;
+	fbReceive: ReceiveString;
+	sReceivedString: STRING;
+	sLastReceivedString: STRING;
+	bStringReceived: BOOL;
+	bReceiveBusy: BOOL;
+	bReceiveError: BOOL;
+	eReceiveErrorID: ComError_t;
+	bReceiveTimeout: BOOL;
+	nReceiveCounter: UDINT;
+	nSendCounter: UDINT;
+	sStringToSend: STRING;
+	fbFormatString: FB_FormatString;
+	
+	// Parameters for state-machine implementation
+	nStep: INT := 0;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[fbEL6Ctrl(
+	Mode:= SERIALLINEMODE_EL6_22B, 
+	pComIn:= ADR(stIn_EL6), 
+	pComOut:= ADR(stOut_EL6), 
+	SizeComIn:= UINT_TO_INT(SIZEOF(stIn_EL6)), 
+	Error=> , 
+	ErrorID=> eSerialLineErrorID, 
+	TxBuffer:= TxBuffer, 
+	RxBuffer:= RxBuffer );
+IF fbEL6Ctrl.Error THEN
+	bEL6CtrlError := TRUE;
+	eEL6CtrlErrorID := fbEL6Ctrl.ErrorID;
+END_IF
+IF bSend THEN
+	nStep := 10;
+	bSend := FALSE;
+	bDone := FALSE;
+END_IF
+// Attempt at solution that sends one command at a time, not on constant loop
+CASE nStep OF
+	0:
+		; // idle
+	10:
+		// Clear buffers in case any lingering data
+		fbClearComBuffer(Buffer:=TxBuffer);
+		fbClearComBuffer(Buffer:=RxBuffer);
+		// Prepare string to send
+		sStringToSend := CONCAT(sSendPrefix, CONCAT(sCmd, sSendSuffix));
+		// Send string
+		fbSend(	SendString:= sStringToSend,
+				TXbuffer:= TxBuffer,
+				Busy=> bSendBusy,
+				Error=> eSendErrorID);
+		IF fbSend.Error <> COMERROR_NOERROR THEN
+			eLastSendErrorID := fbSend.Error;
+		ELSE
+			nSendCounter := nSendCounter + 1;
+		END_IF
+		nStep := nStep + 10;
+	20:
+		// Finish sending String
+		IF fbSend.Busy THEN
+			fbSend(	SendString:= sStringToSend,
+					TXbuffer:= TxBuffer,
+					Busy=> bSendBusy,
+					Error=> eSendErrorID);
+			IF fbSend.Error <> COMERROR_NOERROR THEN
+				eLastSendErrorID := fbSend.Error;
+			ELSE
+				nSendCounter := nSendCounter + 1;
+			END_IF
+		ELSE
+			nStep := nStep + 10;
+		END_IF
+	30:
+		// Get Reply
+		fbReceive(
+			Prefix:= sRecvPrefix,
+			Suffix:= sRecvSuffix,
+			Timeout:= tTimeout,
+			ReceivedString:= sReceivedString,
+			RXbuffer:= RxBuffer,
+			StringReceived=> bStringReceived,
+			Busy=> bReceiveBusy,
+			Error=> eRecvErrorID,
+			RxTimeout=> bReceiveTimeout );
+		IF fbReceive.Error <> COMERROR_NOERROR THEN
+			eReceiveErrorID := fbReceive.Error;
+		END_IF
+		IF bStringReceived THEN
+			nReceiveCounter := nReceiveCounter + 1;
+			// Check for response
+			IF FIND(sReceivedString, sStringToSend)=0 THEN
+				sResponse := sReceivedString;
+				bDone := TRUE;
+				nStep := 0;
+			END_IF
+		END_IF
+END_CASE]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/LCLSGeneral/LCLSGeneral/POUs/Hardware/FB_ThermoCouple.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Hardware/FB_ThermoCouple.TcPOU
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.12">
+  <POU Name="FB_ThermoCouple" Id="{cc00895a-0264-4382-820e-9cfa9062e545}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_ThermoCouple
+(* Handles scaling and default diagnostics for thermocouple terminals *)
+VAR_INPUT
+	// Ratio between raw value and actual temperature. Default is 10 for 10 steps per degree (or 0.1 degree resolution)
+	iScale: INT := 10;
+END_VAR
+VAR_OUTPUT
+	{attribute 'pytmc' := '
+		pv: TEMP
+		io: input
+	'}
+	fTemp: LREAL;
+	
+	{attribute 'pytmc' := '
+		pv: CONN
+		io: input
+		ONAM: Connected
+		ZNAM: Disconnected
+	}
+	bConnected: BOOL;
+	
+	{attribute 'pytmc' := '
+		pv: ERR
+		io: input
+	'}
+	bError AT %I*: BOOL;
+	
+	bUnderrange AT %I*: BOOL;
+	bOverrange AT %I*: BOOL;
+END_VAR
+VAR
+	iRaw AT %I*: INT;
+END_VAR]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[bConnected := NOT (bOverrange AND bError);
+fTemp := iRaw / iScale;]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>


### PR DESCRIPTION
This is a set of function blocks I've been working on for various projects that I thought would be more broadly useful. I'm doing some final testing of these, so don't merge yet, but I'd appreciate help reviewing how I've done things or even if these all belong here.

Adding:
- Ways to buffer data at high rate into arrays that can be read out in pytmc all at once
- Unix timestamp emulation (for the elements of these arrays)
- Helpers for analog input, analog output, serial, and thermocouple terminals
- Utility for quickly polling a CoE parameter