### PR TITLE
FIX: logging format

### DIFF
--- a/LCLSGeneral/LCLSGeneral/POUs/Logger/FB_LogMessage.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Logger/FB_LogMessage.TcPOU
@@ -21,6 +21,7 @@ This could be summarized as:
 where dash '-' is used as the "nil value" or `csNILVALUE` here.
 *)
 
+{attribute 'reflection'}
 FUNCTION_BLOCK FB_LogMessage
 VAR_INPUT	
 	i_sMsg	:	STRING; //Message to send
@@ -30,7 +31,9 @@ END_VAR
 VAR
 	fbFormatString		:	FB_FormatString; //String formatter
 	sPRIVAL				: 	T_MaxString := csNILVALUE; //Priority value
-	sPID				: 	T_MaxString := csNILVALUE; //Unused
+	{attribute 'instance-path'}
+	{attribute 'noinit'}
+	sPID				: 	T_MaxString; //PID -> changed to instance path
 	sSubsystem			: 	T_MaxString := csNILVALUE; //Type of subsystem for organizing in syslog later
 	nSyslogVer			: 	WORD := cnSyslogVer; //Version of syslog
 	sMsg				: 	T_MaxString := csNILVALUE; //Message to send
@@ -48,7 +51,6 @@ fbLoggerBuffer.cbBuffer := UINT_TO_UDINT(SIZEOF(asLoggerMesgBuffer));
 fbFormatString.sFormat := '<%s>%d %s %s %s %s %s - %s';
 
 sPRIVAL := LEFT( WORD_TO_STRING(cnFacility * 8 + i_eSevr), 5);
-sPID := csNILVALUE;
 sSubsystem := casSubsystems[i_eSubsystem];
 nSyslogVer := cnSyslogVer;
 sMsg := i_sMsg;

--- a/LCLSGeneral/LCLSGeneral/POUs/Logger/FB_LogMessage.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Logger/FB_LogMessage.TcPOU
@@ -1,9 +1,26 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.12">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
   <POU Name="FB_LogMessage" Id="{fe506c1b-49fd-40e1-9f69-3fdf525bddb1}" SpecialFunc="None">
     <Declaration><![CDATA[// LogMessage
 // A Wallace, 18-4-12
 // Adds a message to the global queue to be sent to the syslog server
+(* 
+For reference, the logstash pattern SYSLOG5424LINE will be used to grok the generated syslog-5424 message.
+
+	 SYSLOG5424PRI <%{NONNEGINT:syslog5424_pri}>
+	 SYSLOG5424SD \[%{DATA}\]+
+	 SYSLOG5424BASE %{SYSLOG5424PRI}%{NONNEGINT:syslog5424_ver} +(?:%{TIMESTAMP_ISO8601:syslog5424_ts}|-) +(?:%{IPORHOST:syslog5424_host}|-) 
+					+(-|%{SYSLOG5424PRINTASCII:syslog5424_app}) +(-|%{SYSLOG5424PRINTASCII:syslog5424_proc}) 
+					+(-|%{SYSLOG5424PRINTASCII:syslog5424_msgid}) +(?:%{SYSLOG5424SD:syslog5424_sd}|-|)
+	 SYSLOG5424LINE %{SYSLOG5424BASE} +%{GREEDYDATA:syslog5424_msg}
+
+This could be summarized as:
+
+	<PRI> VER TIMESTAMP/- IPorHOST/- APP/- PROC/- MSGID/- SD/- MESSAGE
+
+where dash '-' is used as the "nil value" or `csNILVALUE` here.
+*)
+
 FUNCTION_BLOCK FB_LogMessage
 VAR_INPUT	
 	i_sMsg	:	STRING; //Message to send

--- a/LCLSGeneral/LCLSGeneral/POUs/Logger/FB_LogMessage.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Logger/FB_LogMessage.TcPOU
@@ -28,21 +28,15 @@ VAR_INPUT
 	i_eSubsystem	:	E_Subsystem; //In-lieu of App-name in the RFC-5424
 END_VAR
 VAR
-
 	fbFormatString		:	FB_FormatString; //String formatter
 	sPRIVAL				: 	T_MaxString := csNILVALUE; //Priority value
 	sPID				: 	T_MaxString := csNILVALUE; //Unused
 	sSubsystem			: 	T_MaxString := csNILVALUE; //Type of subsystem for organizing in syslog later
 	nSyslogVer			: 	WORD := cnSyslogVer; //Version of syslog
-	sSD					: 	T_MaxString := csNILVALUE; //Unused
 	sMsg				: 	T_MaxString := csNILVALUE; //Message to send
+	sMsgID				: 	T_MaxString := csNILVALUE; // Message ID
 END_VAR
 VAR CONSTANT
-	{attribute 'naming' := 'off'}
-	i_sPID	:	STRING := csNILVALUE;	//Not currently used
-	i_sMSGID	:	STRING := csNILVALUE; //Not currently used
-	i_sSD	:	STRING := csNILVALUE; //Not currently used
-	{attribute 'naming' := 'on'}
 	casSubsystems	:	ARRAY [0..5] OF STRING := ['-', 'VACUUM', 'MPS', 'MOTION', 'FIELDBUS', 'SDS']; //LCLS defined subsystems for global logging
 	cnFacility: WORD := 20; // local4
 END_VAR]]></Declaration>
@@ -51,22 +45,23 @@ END_VAR]]></Declaration>
 fbLoggerBuffer.pBuffer := ADR(asLoggerMesgBuffer); //Global buffer address
 fbLoggerBuffer.cbBuffer := UINT_TO_UDINT(SIZEOF(asLoggerMesgBuffer));
 
-fbFormatString.sFormat := '<%s> %d %s %s %s %s BOM%s';
+fbFormatString.sFormat := '<%s>%d %s %s %s %s %s - %s';
 
 sPRIVAL := LEFT( WORD_TO_STRING(cnFacility * 8 + i_eSevr), 5);
 sPID := csNILVALUE;
 sSubsystem := casSubsystems[i_eSubsystem];
 nSyslogVer := cnSyslogVer;
-sSD := i_sSD;
 sMsg := i_sMsg;
+
 //bad language ahead, sorry
-fbFormatString.arg1 := F_STRING(sPRIVAL);
-fbFormatString.arg2 := F_WORD(nSyslogVer);
-fbFormatString.arg3 := F_STRING(gsCurrentTime);
-fbFormatString.arg4 := F_STRING(sSubsystem);
-fbFormatString.arg5 := F_STRING(sPID);
-fbFormatString.arg6 := F_STRING(sSD);
-fbFormatString.arg7 := F_STRING(sMsg);
+fbFormatString.arg1 := F_STRING(sPRIVAL); 			// <PRI>
+fbFormatString.arg2 := F_WORD(nSyslogVer);			// VER
+fbFormatString.arg3 := F_STRING(gsCurrentTime);		// TIMESTAMP
+fbFormatString.arg4 := F_STRING(gsHostName);		// IPorHOST/-
+fbFormatString.arg5 := F_STRING(sSubsystem);		// APP/-
+fbFormatString.arg6 := F_STRING(sPID);				// PROC/-
+fbFormatString.arg7 := F_STRING(sMsgID);			// MSGID/-
+fbFormatString.arg8 := F_STRING(sMsg);				// MESSAGE
 fbFormatString( sOut=>fbLoggerBuffer.putValue);
 fbLoggerBuffer.A_AddTail();]]></ST>
     </Implementation>

--- a/LCLSGeneral/LCLSGeneral/POUs/Logger/FB_LogMessage.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Logger/FB_LogMessage.TcPOU
@@ -53,9 +53,5 @@ fbFormatString.arg7 := F_STRING(sMsg);
 fbFormatString( sOut=>fbLoggerBuffer.putValue);
 fbLoggerBuffer.A_AddTail();]]></ST>
     </Implementation>
-    <LineIds Name="FB_LogMessage">
-      <LineId Id="420" Count="20" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
   </POU>
 </TcPlcObject>

--- a/LCLSGeneral/LCLSGeneral/POUs/Logger/FB_Logger.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Logger/FB_Logger.TcPOU
@@ -29,7 +29,6 @@ VAR
 	ctuSentSomething	:	CTU := (PV := 100); //Diagnostic to indicate this thing is working. Increments with each successful send.
 	{attribute 'naming' := 'omit'}
 	rtSocketSendErr		:	R_TRIG; //Socket send error sensor
-	sHostName	:	T_MaxString := csNILVALUE; //PLC hostname holder
 END_VAR
 VAR CONSTANT
 	cPSLogHost	: T_IPv4Addr := '172.21.32.9'; //syslog host
@@ -49,9 +48,9 @@ END_IF
 
 fbGetHostName();
 IF NOT (fbGetHostName.bBusy OR fbGetHostName.bError) THEN
-	sHostName := fbGetHostName.sHostName;
+	gsHostName := fbGetHostName.sHostName;
 ELSE
-	sHostName := csNILVALUE;
+	gsHostName := csNILVALUE;
 END_IF
 
 rtReset(CLK:=i_xReset);

--- a/LCLSGeneral/LCLSGeneral/POUs/Logger/FB_Logger.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Logger/FB_Logger.TcPOU
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.12">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
   <POU Name="FB_Logger" Id="{227c1bce-209d-4aad-8160-124282bb6370}" SpecialFunc="None">
     <Declaration><![CDATA[(* Syslog Logger
 A. Wallace 2016-9-3
@@ -88,21 +88,5 @@ ELSIF fbUDPSocket.eState = E_SocketConnectionlessState.eSOCKET_CREATED THEN
 	rtSocketSendErr(CLK:=fbUDPSocketSend.bError);
 END_IF]]></ST>
     </Implementation>
-    <LineIds Name="FB_Logger">
-      <LineId Id="1168" Count="18" />
-      <LineId Id="1189" Count="0" />
-      <LineId Id="1191" Count="0" />
-      <LineId Id="1227" Count="0" />
-      <LineId Id="1192" Count="0" />
-      <LineId Id="1194" Count="3" />
-      <LineId Id="1219" Count="0" />
-      <LineId Id="1198" Count="0" />
-      <LineId Id="1220" Count="0" />
-      <LineId Id="1225" Count="0" />
-      <LineId Id="1200" Count="8" />
-      <LineId Id="1217" Count="1" />
-      <LineId Id="1210" Count="6" />
-      <LineId Id="978" Count="0" />
-    </LineIds>
   </POU>
 </TcPlcObject>

--- a/LCLSGeneral/LCLSGeneral/POUs/Logger/GVL_Logger.TcGVL
+++ b/LCLSGeneral/LCLSGeneral/POUs/Logger/GVL_Logger.TcGVL
@@ -12,7 +12,8 @@ VAR_GLOBAL CONSTANT
 END_VAR
 VAR_GLOBAL
 	asLoggerMesgBuffer	:	ARRAY [0..cnLoggerMesgArraySize] OF T_MaxString; //Logger message buffer, FB_LogMessage puts messages in here for FB_Logger to send out
-	gsCurrentTime	:	T_MaxString := csNILVALUE; //For timestamping messages
+	gsCurrentTime	:	T_MaxString := '-'; //For timestamping messages
+	gsHostName	:	T_MaxString := '-'; //Hostname used for log messages
 	{analysis -33}
 	fbLogMessage : FB_LogMessage; //Instantiated here to be used everywhere
 	{analysis +33}

--- a/LCLSGeneral/LCLSGeneral/POUs/Logger/GVL_Logger.TcGVL
+++ b/LCLSGeneral/LCLSGeneral/POUs/Logger/GVL_Logger.TcGVL
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.12">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
   <GVL Name="GVL_Logger" Id="{047a20cc-a785-4614-8465-ede098785b35}">
     <Declaration><![CDATA[{attribute 'qualified only'}
 //Global variables for logging to syslog

--- a/LCLSGeneral/LCLSGeneral/POUs/Logger/GVL_Logger.TcGVL
+++ b/LCLSGeneral/LCLSGeneral/POUs/Logger/GVL_Logger.TcGVL
@@ -12,8 +12,8 @@ VAR_GLOBAL CONSTANT
 END_VAR
 VAR_GLOBAL
 	asLoggerMesgBuffer	:	ARRAY [0..cnLoggerMesgArraySize] OF T_MaxString; //Logger message buffer, FB_LogMessage puts messages in here for FB_Logger to send out
-	gsCurrentTime	:	T_MaxString := '-'; //For timestamping messages
-	gsHostName	:	T_MaxString := '-'; //Hostname used for log messages
+	gsCurrentTime	:	T_MaxString := csNILVALUE; //For timestamping messages
+	gsHostName	:	T_MaxString := csNILVALUE; //Hostname used for log messages
 	{analysis -33}
 	fbLogMessage : FB_LogMessage; //Instantiated here to be used everywhere
 	{analysis +33}


### PR DESCRIPTION
Closes #8 
Closes #11 

This is confirmed to be working with logstash, using the following filter configuration:
<details>

```
filter {
  if [type] == "syslog5424" {
    grok {
      match => { "message" => "%{SYSLOG5424LINE}" }
      add_field => [ "received_at", "%{@timestamp}" ]
      add_field => [ "received_from", "%{host}" ]
    }
    date {
      match => [ "syslog_timestamp", "MMM  d HH:mm:ss", "MMM dd HH:mm:ss" ]
    }
  }
}
```
</details>

Additionally, this changes the PID portion of the syslog message to use TwinCAT reflection and find the `FB_LogMessage` path. I think it's probably an appropriate section for it, but I could be dissuaded here.

This would mean then that those who want to log messages should _not_ use the provided GVL logger, but instantiate their own `FB_LogMessage` to get the desired level of granularity of the log message path.

With a log message from a test project, the resulting JSON dumped from kibana is as follows:

<details>

```json
{
  "_index": "logstash-2019.10.02-000001",
  "_type": "_doc",
  "_id": "wmng-m0B5y_5dq3ddYXV",
  "_version": 1,
  "_score": null,
  "_source": {
    "@timestamp": "2019-10-23T23:07:57.167Z",
    "syslog5424_app": "MOTION",
    "syslog5424_ts": "2019-10-24T00:50:19.682Z",
    "host": "gateway",
    "@version": "1",
    "port": 38900,
    "received_at": "2019-10-23T23:07:57.167Z",
    "message": "<162>1 2019-10-24T00:50:19.682Z plc-tst-proto2 MOTION VirtualMotor.Project.Main.fbLogger - - the message",
    "syslog5424_ver": "1",
    "syslog5424_proc": "VirtualMotor.Project.Main.fbLogger",
    "type": "syslog5424",
    "syslog5424_msg": "the message",
    "syslog5424_host": "plc-tst-proto2",
    "received_from": "gateway",
    "syslog5424_pri": "162"
  },
  "fields": {
    "@timestamp": [
      "2019-10-23T23:07:57.167Z"
    ]
  },
  "sort": [
    1571872077167
  ]
}
```
</details>