### PR TITLE
ENH: log to built-in twincat event logger as well as syslog + EPICS PV

### DIFF
--- a/LCLSGeneral/LCLSGeneral.tsproj
+++ b/LCLSGeneral/LCLSGeneral.tsproj
@@ -61,11 +61,91 @@
 				<Hide GUID="{B6598B95-DC2C-454C-9B12-DE628B32D897}"/>
 			</Hides>
 		</DataType>
+		<DataType>
+			<Name GUID="{EF2A8078-F347-4D07-ADF5-CB5BE720316E}" PersistentType="true">NewEventClass</Name>
+			<DisplayName TxtId="">
+				<![CDATA[NewEventClass_DisplayText]]>
+			</DisplayName>
+			<EventId>
+				<Name Id="1">Event</Name>
+				<DisplayName TxtId="">
+					<![CDATA[Event_DisplayText]]>
+				</DisplayName>
+				<Severity>Verbose</Severity>
+			</EventId>
+		</DataType>
+		<DataType>
+			<Name GUID="{16BEE339-E307-4BC2-8E77-D5FB1794DF5A}" PersistentType="true">LCLSLoggingEventClass</Name>
+			<DisplayName TxtId="">
+				<![CDATA[Log event]]>
+			</DisplayName>
+			<EventId>
+				<Name Id="0">LoggingEmergencyEvent</Name>
+				<DisplayName TxtId="">
+					<![CDATA[Emergency]]>
+				</DisplayName>
+				<Severity>Critical</Severity>
+			</EventId>
+			<EventId>
+				<Name Id="1">LoggingAlertEvent</Name>
+				<DisplayName TxtId="">
+					<![CDATA[Alert]]>
+				</DisplayName>
+				<Severity>Critical</Severity>
+			</EventId>
+			<EventId>
+				<Name Id="2">LoggingCriticalEvent</Name>
+				<DisplayName TxtId="">
+					<![CDATA[Critical]]>
+				</DisplayName>
+				<Severity>Critical</Severity>
+			</EventId>
+			<EventId>
+				<Name Id="3">LoggingErrorEvent</Name>
+				<DisplayName TxtId="">
+					<![CDATA[Error]]>
+				</DisplayName>
+				<Severity>Error</Severity>
+			</EventId>
+			<EventId>
+				<Name Id="4">LoggingWarningEvent</Name>
+				<DisplayName TxtId="">
+					<![CDATA[Warning]]>
+				</DisplayName>
+				<Severity>Warning</Severity>
+			</EventId>
+			<EventId>
+				<Name Id="5">LoggingNoticeEvent</Name>
+				<DisplayName TxtId="">
+					<![CDATA[Notice]]>
+				</DisplayName>
+				<Severity>Info</Severity>
+			</EventId>
+			<EventId>
+				<Name Id="6">LoggingInfoEvent</Name>
+				<DisplayName TxtId="">
+					<![CDATA[Info]]>
+				</DisplayName>
+				<Severity>Info</Severity>
+			</EventId>
+			<EventId>
+				<Name Id="7">LoggingDebugEvent</Name>
+				<DisplayName TxtId="">
+					<![CDATA[Debug]]>
+				</DisplayName>
+				<Severity>Verbose</Severity>
+			</EventId>
+			<Hides>
+				<Hide GUID="{E50B8F82-4C54-4F5A-855E-90970D01354A}"/>
+				<Hide GUID="{772B0B6F-412E-46FD-9006-6E00BFFE1C3D}"/>
+				<Hide GUID="{8FAD87A4-C885-4A4F-85AF-8AB324945AE2}"/>
+			</Hides>
+		</DataType>
 	</DataTypes>
 	<Project ProjectGUID="{9AC02CD1-4FA4-49DE-BC09-848126C612E3}" Target64Bit="true" ShowHideConfigurations="#x6">
 		<Plc>
 			<Project GUID="{DF4CAFE9-8807-49B7-953A-22D467A15EF7}" Name="LCLSGeneral" PrjFilePath="LCLSGeneral\LCLSGeneral.plcproj" TmcFilePath="LCLSGeneral\LCLSGeneral.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e">
-				<Instance Id="#x01010010" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2">
+				<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="LCLSGeneral\LCLSGeneral.tmc">
 					<Name>LCLSGeneral Instance</Name>
 					<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 				</Instance>

--- a/LCLSGeneral/LCLSGeneral.tsproj
+++ b/LCLSGeneral/LCLSGeneral.tsproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<TcSmProject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4020.14">
+<TcSmProject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4022.30">
 	<DataTypes>
 		<DataType>
 			<Name GUID="{85DC3E7A-8ADA-435B-9479-25573909A7DB}" Namespace="AX5000" TcBaseType="true">E_AX5000_P_0275_ActiveFeedbackAndMemory</Name>
@@ -142,7 +142,7 @@
 			</Hides>
 		</DataType>
 	</DataTypes>
-	<Project ProjectGUID="{9AC02CD1-4FA4-49DE-BC09-848126C612E3}" Target64Bit="true" ShowHideConfigurations="#x6">
+	<Project ProjectGUID="{9AC02CD1-4FA4-49DE-BC09-848126C612E3}" TargetNetId="172.21.148.145.1.1" ShowHideConfigurations="#x6">
 		<Plc>
 			<Project GUID="{DF4CAFE9-8807-49B7-953A-22D467A15EF7}" Name="LCLSGeneral" PrjFilePath="LCLSGeneral\LCLSGeneral.plcproj" TmcFilePath="LCLSGeneral\LCLSGeneral.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e">
 				<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="LCLSGeneral\LCLSGeneral.tmc">

--- a/LCLSGeneral/LCLSGeneral/GVLs/DefaultGlobals.TcGVL
+++ b/LCLSGeneral/LCLSGeneral/GVLs/DefaultGlobals.TcGVL
@@ -1,11 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.12">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
   <GVL Name="DefaultGlobals" Id="{2d2569a9-cdb9-4b2c-9048-e9448cd0d09e}">
     <Declaration><![CDATA[//These are variables every PLC project should have
 VAR_GLOBAL
 	
 	stSys	:	ST_System; //Included for you
 	fTimeStamp: LREAL;
+	
 END_VAR]]></Declaration>
   </GVL>
 </TcPlcObject>

--- a/LCLSGeneral/LCLSGeneral/LCLSGeneral.plcproj
+++ b/LCLSGeneral/LCLSGeneral/LCLSGeneral.plcproj
@@ -105,6 +105,9 @@
     <Compile Include="POUs\Logger\FB_LogMessage.TcPOU">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="POUs\Logger\FB_MessageToEventLogger.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="POUs\Logger\GVL_Logger.TcGVL">
       <SubType>Code</SubType>
       <LinkAlways>true</LinkAlways>
@@ -151,11 +154,27 @@
       <DefaultResolution>Tc2_Utilities, * (Beckhoff Automation GmbH)</DefaultResolution>
       <Namespace>Tc2_Utilities</Namespace>
     </PlaceholderReference>
+    <PlaceholderReference Include="Tc3_EventLogger">
+      <DefaultResolution>Tc3_EventLogger, * (Beckhoff Automation GmbH)</DefaultResolution>
+      <Namespace>Tc3_EventLogger</Namespace>
+    </PlaceholderReference>
+    <PlaceholderReference Include="Tc3_Module">
+      <DefaultResolution>Tc3_Module, * (Beckhoff Automation GmbH)</DefaultResolution>
+      <Namespace>Tc3_Module</Namespace>
+    </PlaceholderReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="LCLSGeneral.tmc">
       <SubType>Content</SubType>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <PlaceholderResolution Include="Tc3_EventLogger">
+      <Resolution>Tc3_EventLogger, * (Beckhoff Automation GmbH)</Resolution>
+    </PlaceholderResolution>
+  </ItemGroup>
+  <ItemGroup>
+    <PinnedGlobalDataType Include="ST_LCLSLoggingEventClass" />
   </ItemGroup>
   <ProjectExtensions>
     <PlcProjectOptions>

--- a/LCLSGeneral/LCLSGeneral/POUs/Hardware/FB_ThermoCouple.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Hardware/FB_ThermoCouple.TcPOU
@@ -22,7 +22,7 @@ VAR_OUTPUT
 		io: input
 		field: ONAM Connected
 		field: ZNAM Disconnected
-	}
+	'}
 	bConnected: BOOL;
 	
 	{attribute 'pytmc' := '

--- a/LCLSGeneral/LCLSGeneral/POUs/Logger/FB_LogMessage.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Logger/FB_LogMessage.TcPOU
@@ -38,6 +38,7 @@ VAR
 	nSyslogVer			: 	WORD := cnSyslogVer; //Version of syslog
 	sMsg				: 	T_MaxString := csNILVALUE; //Message to send
 	sMsgID				: 	T_MaxString := csNILVALUE; // Message ID
+	fbEventLogger		: 	FB_MessageToEventLogger;
 END_VAR
 VAR CONSTANT
 	casSubsystems	:	ARRAY [0..5] OF STRING := ['-', 'VACUUM', 'MPS', 'MOTION', 'FIELDBUS', 'SDS']; //LCLS defined subsystems for global logging
@@ -65,7 +66,10 @@ fbFormatString.arg6 := F_STRING(sPID);				// PROC/-
 fbFormatString.arg7 := F_STRING(sMsgID);			// MSGID/-
 fbFormatString.arg8 := F_STRING(sMsg);				// MESSAGE
 fbFormatString( sOut=>fbLoggerBuffer.putValue);
-fbLoggerBuffer.A_AddTail();]]></ST>
+fbLoggerBuffer.A_AddTail();
+
+// Also send the message to the event logger:
+fbEventLogger(i_sMsg:=sMsg, i_eSevr:=i_eSevr, i_eSubsystem:=i_eSubsystem, i_sPath:=sPID);]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/LCLSGeneral/LCLSGeneral/POUs/Logger/FB_Logger.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Logger/FB_Logger.TcPOU
@@ -4,7 +4,7 @@
     <Declaration><![CDATA[(* Syslog Logger
 A. Wallace 2016-9-3
 
-This is used to pass PLC notification messeges to a syslog server.
+This is used to pass PLC notification messages to a syslog server.
 
 This POU constantly attempts to send out messages from the global buffer: GVL_Logger.fbLoggerBuffer.
 This buffer is filled by calling fbLogMessage.
@@ -19,6 +19,10 @@ END_VAR
 VAR
 	fbUDPSocket	        :	FB_ConnectionlessSocket; //Handles creation/deletion of the UDP socket
 	fbUDPSocketSend		:	FB_SocketUdpSendTo; //FB for sending the sOutgoingMesg
+	{attribute 'pytmc' := '
+		pv: LogMessage
+    	io: i
+	'}
 	sOutgoingMesg		:	T_MaxString; //Outgoing message holder
 	stDiag				:	ST_FbDiagnostics; //Generic FB diagnostics, check here for insight into errors/ other FB events
 	{attribute 'naming' := 'omit'}

--- a/LCLSGeneral/LCLSGeneral/POUs/Logger/FB_Logger.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Logger/FB_Logger.TcPOU
@@ -31,8 +31,8 @@ VAR
 	rtSocketSendErr		:	R_TRIG; //Socket send error sensor
 END_VAR
 VAR CONSTANT
-	cPSLogHost	: T_IPv4Addr := '172.21.32.9'; //syslog host
-	cnUdpSyslog	:	UDINT := 514; //syslog port
+	cPSLogHost	: T_IPv4Addr := '172.21.148.141'; //syslog host
+	cnUdpSyslog	:	UDINT := 5000; //syslog port
 END_VAR
 ]]></Declaration>
     <Implementation>

--- a/LCLSGeneral/LCLSGeneral/POUs/Logger/FB_MessageToEventLogger.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Logger/FB_MessageToEventLogger.TcPOU
@@ -26,14 +26,12 @@ END_VAR
     <Implementation>
       <ST><![CDATA[sMessage := i_sMsg;
 
-ipResultMessage.RequestEventText(
-	nLangId:=Tc3_EventLogger.GVL.nLangId_OnlineMonitoring, 
-	sResult:=sMessage, nResultSize:=SIZEOF(sMessage) );
-	
+// Build the message in the name: "(path): message" 
 fbSource.sName := i_sPath;
 fbSource.ExtendName(sExtension:=': ');
-fbSource.ExtendName(sExtension:=i_sMsg);
+fbSource.ExtendName(sExtension:=sMessage);
 
+// Map the message severity to the LCLSLoggingEventClass:
 CASE i_eSevr OF
 	E_MesgSevr.Alert: 		eEventEntry := TC_EVENTS.LCLSLoggingEventClass.LoggingAlertEvent;
 	E_MesgSevr.Critical: 	eEventEntry := TC_EVENTS.LCLSLoggingEventClass.LoggingCriticalEvent;
@@ -49,11 +47,12 @@ hr := fbResult.CreateEx(eEventEntry, 0 (*fbSource*) ); //This uses dyn resources
 
 IF NOT FAILED(hr) THEN
 	hr := fbResult.CreateEx(stEventEntry:=ipResultMessage.stEventEntry, ipSourceInfo:=fbSource);
+	// Send the message if above the trace level:
 	IF NOT FAILED(hr) AND fbResult.eSeverity >= eTraceLevel THEN
 		hr := fbResult.Send(0);
 	END_IF
+	fbResult.Release();
 END_IF
-
 
 IF FAILED(hr) THEN
 	hrLastInternalError := hr;

--- a/LCLSGeneral/LCLSGeneral/POUs/Logger/FB_MessageToEventLogger.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Logger/FB_MessageToEventLogger.TcPOU
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+  <POU Name="FB_MessageToEventLogger" Id="{0893f9f8-65e8-4db6-822f-019a7a161c6c}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_MessageToEventLogger
+VAR_INPUT
+	i_sMsg			: T_MaxString; // Message to send
+	i_eSevr			: E_MesgSevr; // Message severity
+	i_eSubsystem	: E_Subsystem; // Subsystem
+	i_sPath			: T_MaxString; // Path to FB_LogMessage
+END_VAR
+
+VAR_OUTPUT
+END_VAR
+
+VAR
+	sMessage : T_MaxString;
+	fbResult : FB_TcMessage;
+	fbSource : FB_TcSourceInfo;
+	ipResultMessage : I_TcMessage := fbResult;
+	hr : HRESULT;
+	hrLastInternalError : HRESULT;
+	eTraceLevel : TcEventSeverity := TcEventSeverity.Verbose;
+	eEventEntry : TcEventEntry;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[sMessage := i_sMsg;
+
+ipResultMessage.RequestEventText(
+	nLangId:=Tc3_EventLogger.GVL.nLangId_OnlineMonitoring, 
+	sResult:=sMessage, nResultSize:=SIZEOF(sMessage) );
+	
+fbSource.sName := i_sPath;
+fbSource.ExtendName(sExtension:=': ');
+fbSource.ExtendName(sExtension:=i_sMsg);
+
+CASE i_eSevr OF
+	E_MesgSevr.Alert: 		eEventEntry := TC_EVENTS.LCLSLoggingEventClass.LoggingAlertEvent;
+	E_MesgSevr.Critical: 	eEventEntry := TC_EVENTS.LCLSLoggingEventClass.LoggingCriticalEvent;
+	E_MesgSevr.Debug: 		eEventEntry := TC_EVENTS.LCLSLoggingEventClass.LoggingDebugEvent;
+	E_MesgSevr.Emergency: 	eEventEntry := TC_EVENTS.LCLSLoggingEventClass.LoggingEmergencyEvent;
+	E_MesgSevr.Error: 		eEventEntry := TC_EVENTS.LCLSLoggingEventClass.LoggingErrorEvent;
+	E_MesgSevr.Info: 		eEventEntry := TC_EVENTS.LCLSLoggingEventClass.LoggingInfoEvent;
+	E_MesgSevr.Notice: 		eEventEntry := TC_EVENTS.LCLSLoggingEventClass.LoggingNoticeEvent;
+	E_MesgSevr.Warning: 	eEventEntry := TC_EVENTS.LCLSLoggingEventClass.LoggingWarningEvent;
+END_CASE
+
+hr := fbResult.CreateEx(eEventEntry, 0 (*fbSource*) ); //This uses dyn resources and shouldn't be called cyclically.
+
+IF NOT FAILED(hr) THEN
+	hr := fbResult.CreateEx(stEventEntry:=ipResultMessage.stEventEntry, ipSourceInfo:=fbSource);
+	IF NOT FAILED(hr) AND fbResult.eSeverity >= eTraceLevel THEN
+		hr := fbResult.Send(0);
+	END_IF
+END_IF
+
+
+IF FAILED(hr) THEN
+	hrLastInternalError := hr;
+END_IF]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/LCLSGeneral/LCLSGeneral/POUs/Logger/GVL_Logger.TcGVL
+++ b/LCLSGeneral/LCLSGeneral/POUs/Logger/GVL_Logger.TcGVL
@@ -15,7 +15,7 @@ VAR_GLOBAL
 	gsCurrentTime	:	T_MaxString := csNILVALUE; //For timestamping messages
 	gsHostName	:	T_MaxString := csNILVALUE; //Hostname used for log messages
 	{analysis -33}
-	fbLogMessage : FB_LogMessage; //Instantiated here to be used everywhere
+	fbRootLogger : FB_LogMessage; //Instantiated here to be used everywhere
 	{analysis +33}
 	fbLoggerBuffer 			:	FB_StringRingBuffer; //For working with the Logger message buffer
 	


### PR DESCRIPTION
Closes #10 

First pass at logging to the event logger + EPICS PV. 
To get the PV (`:LogMessage`), it will require the user to instantiate and pragma `FB_Logger`.

With the following code:

```
fbLogger(i_sMsg:='the message', i_eSevr:=E_MESGSEVR.Critical,
 i_eSubsystem:= E_Subsystem.MOTION);
```

The event logger outputs:
<img width="1017" alt="image" src="https://user-images.githubusercontent.com/5139267/67708156-e7b06680-f978-11e9-8efd-192f09b10a45.png">

This message also goes via UDP to syslog -> logstash -> elastic search. The logstash JSON is:

<details>

```
{
  "_index": "logstash-2019.10.02-000001",
  "_type": "_doc",
  "_id": "d4W6E24B5y_5dq3dLbKU",
  "_version": 1,
  "_score": null,
  "_source": {
    "@timestamp": "2019-10-28T18:56:38.701Z",
    "syslog5424_app": "MOTION",
    "syslog5424_ts": "2019-10-28T19:39:01.099Z",
    "host": "gateway",
    "@version": "1",
    "port": 40080,
    "received_at": "2019-10-28T18:56:38.701Z",
    "message": "<162>1 2019-10-28T19:39:01.099Z plc-tst-proto2 MOTION VirtualMotor.Project.Main.fbLogger - - the message",
    "syslog5424_ver": "1",
    "syslog5424_proc": "VirtualMotor.Project.Main.fbLogger",
    "type": "syslog5424",
    "syslog5424_msg": "the message",
    "syslog5424_host": "plc-tst-proto2",
    "received_from": "gateway",
    "syslog5424_pri": "162"
  },
  "fields": {
    "@timestamp": [
      "2019-10-28T18:56:38.701Z"
    ]
  },
  "sort": [
    1572288998701
  ]
}
```
</details>

This required adding a new `EventType` "`LCLSLoggingEventClass`" which maps error codes onto specific, fixed strings which are stored in the type system (such that the locale can be used to determine if it should be displayed in English or German). This data type is pinned such that it's accessible to projects which import the library:

<img width="267" alt="image" src="https://user-images.githubusercontent.com/5139267/67709557-69a18f00-f97b-11e9-858a-bc3eeb858edc.png">

I am not using this event logger system as it's intended, as you can see in the following:
`Error	163	10/28/2019 11:35:14 AM 920 ms | 'VirtualMotor.Project.Main.fbLogger: the message': Critical		`
The event type gives the message "`Critical`" here, which _should_ be the full user-defined message. The intention is to keep these fixed/unmodifiable at runtime.

However, I modify the "name" portion, in single quotes above (`'VirtualMotor.Project.Main.fbLogger: the message'`) at runtime, repurposing it to hold our `sPath` and `sMessage`.

Does this seem a reasonable approach? (@ghalym @n-wbrown @slacAWallace @ZLLentz)