### PR TITLE
FIX: Thermocouple reading precision

### DIFF
--- a/LCLSGeneral/LCLSGeneral/POUs/Hardware/FB_ThermoCouple.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Hardware/FB_ThermoCouple.TcPOU
@@ -40,7 +40,7 @@ END_VAR]]></Declaration>
     <Implementation>
       <ST><![CDATA[// The manual states that we are disconnected if we are both overrange and in an error state
 bConnected := NOT (bOverrange AND bError);
-fTemp := iRaw / iScale;]]></ST>
+fTemp := INT_TO_LREAL(iRaw) / iScale;]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>


### PR DESCRIPTION
TC comes in as an INT in unit of 0.1 deg, so we divide by 10 to get the temperature as a float. Dividing two INTs truncates the result, leading to a loss of precision. This fix converts to the final type, LREAL, prior to division so that the result is no longer truncated.