### PR TITLE
ENH: Thermocouple Pragmas and Generalization

### DIFF
--- a/LCLSGeneral/LCLSGeneral/LCLSGeneral.plcproj
+++ b/LCLSGeneral/LCLSGeneral/LCLSGeneral.plcproj
@@ -102,6 +102,9 @@
     <Compile Include="POUs\Hardware\FB_ThermoCouple.TcPOU">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="POUs\Hardware\FB_TempSensor.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="POUs\Logger\DUTs\E_LogEventType_WC.TcDUT">
       <SubType>Code</SubType>
     </Compile>

--- a/LCLSGeneral/LCLSGeneral/POUs/Hardware/FB_TempSensor.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Hardware/FB_TempSensor.TcPOU
@@ -34,7 +34,7 @@ VAR_OUTPUT
         field: ONAM True
         field: ZNAM False
     '}
-    bError AT %I*: BOOL;
+    bError AT %I*: BOOL := TRUE;
 
     bUnderrange AT %I*: BOOL;
     bOverrange AT %I*: BOOL;

--- a/LCLSGeneral/LCLSGeneral/POUs/Hardware/FB_TempSensor.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Hardware/FB_TempSensor.TcPOU
@@ -8,8 +8,8 @@
     2020-03-02 Zachary Lentz
 *)
 VAR_INPUT
-    // Ratio between raw value and actual temperature. Default is 10 for 10 steps per degree (or 0.1 degree resolution)
-    iScale: INT := 10;
+    // Resolution parameter from the Beckhoff docs. Default is 0.1 for 0.1 degree resolution
+    fResolution: LREAL := 0.1;
 END_VAR
 VAR_OUTPUT
     {attribute 'pytmc' := '
@@ -45,11 +45,7 @@ END_VAR]]></Declaration>
     <Implementation>
       <ST><![CDATA[// The manual states that we are disconnected if we are both overrange and in an error state
 bConnected := NOT (bOverrange AND bError);
-IF iScale > 0 THEN // Guard against div by 0
-    fTemp := INT_TO_LREAL(iRaw) / iScale;
-ELSE
-    fTemp := -999; // Obviously fake temperature
-END_IF]]></ST>
+fTemp := INT_TO_LREAL(iRaw) * fResolution;]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/LCLSGeneral/LCLSGeneral/POUs/Hardware/FB_TempSensor.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Hardware/FB_TempSensor.TcPOU
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+  <POU Name="FB_TempSensor" Id="{d7de6be9-251a-4df0-a4bb-4330b01e3329}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_TempSensor
+(*
+    Handles scaling and default diagnostics for temperature sensors,
+    such as thermocouples, RTDs, and others.
+    2020-03-02 Zachary Lentz
+*)
+VAR_INPUT
+    // Ratio between raw value and actual temperature. Default is 10 for 10 steps per degree (or 0.1 degree resolution)
+    iScale: INT := 10;
+END_VAR
+VAR_OUTPUT
+    {attribute 'pytmc' := '
+        pv: TEMP
+        io: input
+        field: EGU C
+        field: PREC 2
+    '}
+    fTemp: LREAL;
+
+    {attribute 'pytmc' := '
+        pv: CONN
+        io: input
+        field: ONAM Connected
+        field: ZNAM Disconnected
+    '}
+    bConnected: BOOL;
+
+    {attribute 'pytmc' := '
+        pv: ERR
+        io: input
+        field: ONAM True
+        field: ZNAM False
+    '}
+    bError AT %I*: BOOL;
+
+    bUnderrange AT %I*: BOOL;
+    bOverrange AT %I*: BOOL;
+END_VAR
+VAR
+    iRaw AT %I*: INT;
+END_VAR]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[// The manual states that we are disconnected if we are both overrange and in an error state
+bConnected := NOT (bOverrange AND bError);
+fTemp := INT_TO_LREAL(iRaw) / iScale;]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/LCLSGeneral/LCLSGeneral/POUs/Hardware/FB_TempSensor.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Hardware/FB_TempSensor.TcPOU
@@ -45,7 +45,11 @@ END_VAR]]></Declaration>
     <Implementation>
       <ST><![CDATA[// The manual states that we are disconnected if we are both overrange and in an error state
 bConnected := NOT (bOverrange AND bError);
-fTemp := INT_TO_LREAL(iRaw) / iScale;]]></ST>
+IF iScale > 0 THEN // Guard against div by 0
+fTemp := INT_TO_LREAL(iRaw) / iScale;
+ELSE
+fTemp := 1E9;
+END_IF]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/LCLSGeneral/LCLSGeneral/POUs/Hardware/FB_TempSensor.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Hardware/FB_TempSensor.TcPOU
@@ -46,9 +46,9 @@ END_VAR]]></Declaration>
       <ST><![CDATA[// The manual states that we are disconnected if we are both overrange and in an error state
 bConnected := NOT (bOverrange AND bError);
 IF iScale > 0 THEN // Guard against div by 0
-fTemp := INT_TO_LREAL(iRaw) / iScale;
+    fTemp := INT_TO_LREAL(iRaw) / iScale;
 ELSE
-fTemp := 1E9;
+    fTemp := -999; // Obviously fake temperature
 END_IF]]></ST>
     </Implementation>
   </POU>

--- a/LCLSGeneral/LCLSGeneral/POUs/Hardware/FB_ThermoCouple.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Hardware/FB_ThermoCouple.TcPOU
@@ -3,7 +3,7 @@
   <POU Name="FB_ThermoCouple" Id="{cc00895a-0264-4382-820e-9cfa9062e545}" SpecialFunc="None">
     <Declaration><![CDATA[FUNCTION_BLOCK FB_ThermoCouple
 (*
-	Handles scaling and default diagnostics for thermocouple terminals
+	Deprecated as of 2020-03-02, please use FB_TempSensor instead
 	2019-10-09 Zachary Lentz
 *)
 VAR_INPUT

--- a/LCLSGeneral/LCLSGeneral/POUs/Hardware/FB_ThermoCouple.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Hardware/FB_ThermoCouple.TcPOU
@@ -6,6 +6,7 @@
 	Deprecated as of 2020-03-02, please use FB_TempSensor instead
 	2019-10-09 Zachary Lentz
 *)
+{warning 'Function Block FB_ThermoCouple is deprecated and may be removed in a future release'}
 VAR_INPUT
 	// Ratio between raw value and actual temperature. Default is 10 for 10 steps per degree (or 0.1 degree resolution)
 	iScale: INT := 10;


### PR DESCRIPTION
`FB_ThermoCouple` actually supports both thermocouples and RTDs, but the semantics need to be generalized a bit. This PR deprecates the old FB and makes a new `FB_TempSensor` with the following pragma changes:

- `STC` is no longer baked into the PV name
- `fTemp` has `EGU` and `PREC` pragmas
- Boolean fields now all have proper `ONAM` and `ZNAM`

Some advice needed: what's the best way to make `PREC` a configurable field? As it is now it is hard-coded, but if I leave `PREC` un-pragmad then I expect that a user's outer `PREC` macro will fill in to the boolean fields as well... Not desired behavior. Is there a way to limit which records the user's outer pragma propagate down to?