### PR TITLE
Scan for a suitable ip

### DIFF
--- a/LCLSGeneral/LCLSGeneral/POUs/Logger/FB_LogHandler.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Logger/FB_LogHandler.TcPOU
@@ -44,6 +44,7 @@ VAR
 	fbGetHostName		:	FB_GetHostName := (bExecute := TRUE, sNetID := ''); //Acquires name of the PLC
     fbGetAdapterIP : FB_GetAdaptersInfo := (bExecute := TRUE, sNetID := ''); // Acquire IP of the correct adapter
 	bHostnameSet	:	BOOL	:= FALSE;
+    idxPortFind : UDINT;
 
 	fbListener		:	REFERENCE TO FB_Listener;
 	fbListeners		: 	ARRAY [0..nNumListeners - 1] OF POINTER TO FB_Listener;
@@ -97,9 +98,15 @@ END_IF
 IF NOT bAdapterSet THEN
     fbGetAdapterIP();
     IF NOT (fbGetAdapterIP.bBusy or fbGetAdapterIP.bError) THEN
-        fbSocket.sLocalHost := fbGetAdapterIP.arrAdapters[1].sIpAddr;
-        SocketEnable := TRUE;
-        bAdapterSet := TRUE;
+        FOR idxPortFind := 0 TO MAX_LOCAL_ADAPTERS DO
+            IF FIND(fbGetAdapterIP.arrAdapters[idxPortFind].sIpAddr,
+               GVL_Logger.sIpTidbit) <> 0 THEN
+                fbSocket.sLocalHost := fbGetAdapterIP.arrAdapters[idxPortFind].sIpAddr;
+                SocketEnable := TRUE;
+                bAdapterSet := TRUE;
+                EXIT;
+            END_IF
+		END_FOR
 	END_IF
 END_IF
 

--- a/LCLSGeneral/LCLSGeneral/POUs/Logger/GVL_Logger.TcGVL
+++ b/LCLSGeneral/LCLSGeneral/POUs/Logger/GVL_Logger.TcGVL
@@ -26,6 +26,8 @@ VAR_GLOBAL CONSTANT
 		field: DESC The log host UDP port
 	'}
 	iLogPort		:	UINT		:= 54321;
+    
+    sIpTidbit : STRING(6) := '172.21';
 END_VAR
 
 VAR_GLOBAL


### PR DESCRIPTION
This may be a solution for [FB log handler is borken](https://github.com/pcdshub/lcls-plc-lfe-vac/issues/8)

Discovered with @ghalym the lack of an active port will screw up the NIC index.