### PR TITLE
ENH: monitor EPICS values for motors + areaDetector centroid

### DIFF
--- a/LCLSGeneral/LCLSGeneral.tsproj
+++ b/LCLSGeneral/LCLSGeneral.tsproj
@@ -1,371 +1,371 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <TcSmProject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4022.30">
-	<DataTypes>
-		<DataType>
-			<Name GUID="{18071995-0000-0000-0000-000000000041}" TcBaseType="true" HideSubItems="true" CName="AmsNetId">AMSNETID</Name>
-			<BitSize>48</BitSize>
-			<BaseType GUID="{18071995-0000-0000-0000-000000000001}">BYTE</BaseType>
-			<ArrayInfo>
-				<LBound>0</LBound>
-				<Elements>6</Elements>
-			</ArrayInfo>
-			<Format>
-				<Printf>%d.%d.%d.%d.%d.%d</Printf>
-				<Parameter>[0]</Parameter>
-				<Parameter>[1]</Parameter>
-				<Parameter>[2]</Parameter>
-				<Parameter>[3]</Parameter>
-				<Parameter>[4]</Parameter>
-				<Parameter>[5]</Parameter>
-			</Format>
-		</DataType>
-		<DataType>
-			<Name GUID="{A81A482A-E7CE-49D8-A4DD-8280773A6946}" PersistentType="true">E_LogEventType</Name>
-			<BitSize>16</BitSize>
-			<BaseType GUID="{18071995-0000-0000-0000-000000000006}">INT</BaseType>
-			<EnumInfo>
-				<Text>
-					<![CDATA[ALARMCLEARED]]>
-				</Text>
-				<Enum>0</Enum>
-			</EnumInfo>
-			<EnumInfo>
-				<Text>
-					<![CDATA[ALARMCONFIRMED]]>
-				</Text>
-				<Enum>1</Enum>
-			</EnumInfo>
-			<EnumInfo>
-				<Text>
-					<![CDATA[ALARMRAISED]]>
-				</Text>
-				<Enum>2</Enum>
-			</EnumInfo>
-			<EnumInfo>
-				<Text>
-					<![CDATA[MESSAGESENT]]>
-				</Text>
-				<Enum>3</Enum>
-			</EnumInfo>
-			<Properties>
-				<Property>
-					<Name>plcAttribute_qualified_only</Name>
-				</Property>
-				<Property>
-					<Name>plcAttribute_strict</Name>
-				</Property>
-			</Properties>
-		</DataType>
-		<DataType>
-			<Name GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}" TcBaseType="true" CName="TcEventSeverity" RemovableEnumPrefix="TCEVENTSEVERITY_">TcEventSeverity</Name>
-			<BitSize>16</BitSize>
-			<BaseType GUID="{18071995-0000-0000-0000-000000000006}">INT</BaseType>
-			<EnumInfo>
-				<Text>
-					<![CDATA[TCEVENTSEVERITY_Verbose]]>
-				</Text>
-				<Enum>0</Enum>
-			</EnumInfo>
-			<EnumInfo>
-				<Text>
-					<![CDATA[TCEVENTSEVERITY_Info]]>
-				</Text>
-				<Enum>1</Enum>
-			</EnumInfo>
-			<EnumInfo>
-				<Text>
-					<![CDATA[TCEVENTSEVERITY_Warning]]>
-				</Text>
-				<Enum>2</Enum>
-			</EnumInfo>
-			<EnumInfo>
-				<Text>
-					<![CDATA[TCEVENTSEVERITY_Error]]>
-				</Text>
-				<Enum>3</Enum>
-			</EnumInfo>
-			<EnumInfo>
-				<Text>
-					<![CDATA[TCEVENTSEVERITY_Critical]]>
-				</Text>
-				<Enum>4</Enum>
-			</EnumInfo>
-			<Properties>
-				<Property>
-					<Name>plcAttribute_qualified_only</Name>
-				</Property>
-				<Property>
-					<Name>plcAttribute_strict</Name>
-				</Property>
-			</Properties>
-			<Hides>
-				<Hide GUID="{777FF09F-0B00-4AF2-BD7C-C1E2CE4A0947}"/>
-				<Hide GUID="{EC3C119D-4FEC-4197-96FB-DAE1B7C403FB}"/>
-			</Hides>
-		</DataType>
-		<DataType>
-			<Name GUID="{32DBDCFB-9DE9-4726-B195-4528904D5F40}" PersistentType="true">ST_LoggingEventInfo</Name>
-			<BitSize>86272</BitSize>
-			<SubItem>
-				<Name>schema</Name>
-				<Type GUID="{18071995-0000-0000-0000-000100000050}">STRING(80)</Type>
-				<Comment>
-					<![CDATA[Message or Alarm{Cleared,Confirmed,Raised} event information
+    <DataTypes>
+        <DataType>
+            <Name GUID="{18071995-0000-0000-0000-000000000041}" TcBaseType="true" HideSubItems="true" CName="AmsNetId">AMSNETID</Name>
+            <BitSize>48</BitSize>
+            <BaseType GUID="{18071995-0000-0000-0000-000000000001}">BYTE</BaseType>
+            <ArrayInfo>
+                <LBound>0</LBound>
+                <Elements>6</Elements>
+            </ArrayInfo>
+            <Format>
+                <Printf>%d.%d.%d.%d.%d.%d</Printf>
+                <Parameter>[0]</Parameter>
+                <Parameter>[1]</Parameter>
+                <Parameter>[2]</Parameter>
+                <Parameter>[3]</Parameter>
+                <Parameter>[4]</Parameter>
+                <Parameter>[5]</Parameter>
+            </Format>
+        </DataType>
+        <DataType>
+            <Name GUID="{A81A482A-E7CE-49D8-A4DD-8280773A6946}" PersistentType="true">E_LogEventType</Name>
+            <BitSize>16</BitSize>
+            <BaseType GUID="{18071995-0000-0000-0000-000000000006}">INT</BaseType>
+            <EnumInfo>
+                <Text>
+                    <![CDATA[ALARMCLEARED]]>
+                </Text>
+                <Enum>0</Enum>
+            </EnumInfo>
+            <EnumInfo>
+                <Text>
+                    <![CDATA[ALARMCONFIRMED]]>
+                </Text>
+                <Enum>1</Enum>
+            </EnumInfo>
+            <EnumInfo>
+                <Text>
+                    <![CDATA[ALARMRAISED]]>
+                </Text>
+                <Enum>2</Enum>
+            </EnumInfo>
+            <EnumInfo>
+                <Text>
+                    <![CDATA[MESSAGESENT]]>
+                </Text>
+                <Enum>3</Enum>
+            </EnumInfo>
+            <Properties>
+                <Property>
+                    <Name>plcAttribute_qualified_only</Name>
+                </Property>
+                <Property>
+                    <Name>plcAttribute_strict</Name>
+                </Property>
+            </Properties>
+        </DataType>
+        <DataType>
+            <Name GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}" TcBaseType="true" CName="TcEventSeverity" RemovableEnumPrefix="TCEVENTSEVERITY_">TcEventSeverity</Name>
+            <BitSize>16</BitSize>
+            <BaseType GUID="{18071995-0000-0000-0000-000000000006}">INT</BaseType>
+            <EnumInfo>
+                <Text>
+                    <![CDATA[TCEVENTSEVERITY_Verbose]]>
+                </Text>
+                <Enum>0</Enum>
+            </EnumInfo>
+            <EnumInfo>
+                <Text>
+                    <![CDATA[TCEVENTSEVERITY_Info]]>
+                </Text>
+                <Enum>1</Enum>
+            </EnumInfo>
+            <EnumInfo>
+                <Text>
+                    <![CDATA[TCEVENTSEVERITY_Warning]]>
+                </Text>
+                <Enum>2</Enum>
+            </EnumInfo>
+            <EnumInfo>
+                <Text>
+                    <![CDATA[TCEVENTSEVERITY_Error]]>
+                </Text>
+                <Enum>3</Enum>
+            </EnumInfo>
+            <EnumInfo>
+                <Text>
+                    <![CDATA[TCEVENTSEVERITY_Critical]]>
+                </Text>
+                <Enum>4</Enum>
+            </EnumInfo>
+            <Properties>
+                <Property>
+                    <Name>plcAttribute_qualified_only</Name>
+                </Property>
+                <Property>
+                    <Name>plcAttribute_strict</Name>
+                </Property>
+            </Properties>
+            <Hides>
+                <Hide GUID="{777FF09F-0B00-4AF2-BD7C-C1E2CE4A0947}"/>
+                <Hide GUID="{EC3C119D-4FEC-4197-96FB-DAE1B7C403FB}"/>
+            </Hides>
+        </DataType>
+        <DataType>
+            <Name GUID="{32DBDCFB-9DE9-4726-B195-4528904D5F40}" PersistentType="true">ST_LoggingEventInfo</Name>
+            <BitSize>86272</BitSize>
+            <SubItem>
+                <Name>schema</Name>
+                <Type GUID="{18071995-0000-0000-0000-000100000050}">STRING(80)</Type>
+                <Comment>
+                    <![CDATA[Message or Alarm{Cleared,Confirmed,Raised} event information
 
         Note that elements here do not follow the usual Hungarian notation / 
         variable-type-prefixing naming convention due to the member names being
         used directly in the generation of the JSON document.]]>
-				</Comment>
-				<BitSize>648</BitSize>
-				<BitOffs>0</BitOffs>
-				<Default>
-					<String>
-						<![CDATA[twincat-event-0]]>
-					</String>
-				</Default>
-				<Properties>
-					<Property>
-						<Name>plcAttribute_pytmc</Name>
-						<Value>pv: Schema
+                </Comment>
+                <BitSize>648</BitSize>
+                <BitOffs>0</BitOffs>
+                <Default>
+                    <String>
+                        <![CDATA[twincat-event-0]]>
+                    </String>
+                </Default>
+                <Properties>
+                    <Property>
+                        <Name>plcAttribute_pytmc</Name>
+                        <Value>pv: Schema
         io: i
         field: DESC Schema string</Value>
-					</Property>
-				</Properties>
-			</SubItem>
-			<SubItem>
-				<Name>ts</Name>
-				<Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
-				<BitSize>64</BitSize>
-				<BitOffs>704</BitOffs>
-				<Properties>
-					<Property>
-						<Name>plcAttribute_pytmc</Name>
-						<Value>pv: Timestamp 
+                    </Property>
+                </Properties>
+            </SubItem>
+            <SubItem>
+                <Name>ts</Name>
+                <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+                <BitSize>64</BitSize>
+                <BitOffs>704</BitOffs>
+                <Properties>
+                    <Property>
+                        <Name>plcAttribute_pytmc</Name>
+                        <Value>pv: Timestamp 
         io: i
         field: DESC Unix timestamp</Value>
-					</Property>
-				</Properties>
-			</SubItem>
-			<SubItem>
-				<Name>plc</Name>
-				<Type GUID="{18071995-0000-0000-0000-000100000050}">STRING(80)</Type>
-				<BitSize>648</BitSize>
-				<BitOffs>768</BitOffs>
-				<Properties>
-					<Property>
-						<Name>plcAttribute_pytmc</Name>
-						<Value>pv: Hostname 
+                    </Property>
+                </Properties>
+            </SubItem>
+            <SubItem>
+                <Name>plc</Name>
+                <Type GUID="{18071995-0000-0000-0000-000100000050}">STRING(80)</Type>
+                <BitSize>648</BitSize>
+                <BitOffs>768</BitOffs>
+                <Properties>
+                    <Property>
+                        <Name>plcAttribute_pytmc</Name>
+                        <Value>pv: Hostname 
         io: i
         field: DESC PLC Hostname</Value>
-					</Property>
-				</Properties>
-			</SubItem>
-			<SubItem>
-				<Name>severity</Name>
-				<Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
-				<BitSize>16</BitSize>
-				<BitOffs>1424</BitOffs>
-				<Properties>
-					<Property>
-						<Name>plcAttribute_pytmc</Name>
-						<Value>pv: Severity
+                    </Property>
+                </Properties>
+            </SubItem>
+            <SubItem>
+                <Name>severity</Name>
+                <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
+                <BitSize>16</BitSize>
+                <BitOffs>1424</BitOffs>
+                <Properties>
+                    <Property>
+                        <Name>plcAttribute_pytmc</Name>
+                        <Value>pv: Severity
         io: i
         field: DESC TcEventSeverity	
         field: ZRST Verbose
         field: ONST Info
         field: TWST Warning
         field: THST Error</Value>
-					</Property>
-				</Properties>
-			</SubItem>
-			<SubItem>
-				<Name>id</Name>
-				<Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-				<BitSize>32</BitSize>
-				<BitOffs>1440</BitOffs>
-				<Properties>
-					<Property>
-						<Name>plcAttribute_pytmc</Name>
-						<Value>pv: MessageID
+                    </Property>
+                </Properties>
+            </SubItem>
+            <SubItem>
+                <Name>id</Name>
+                <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+                <BitSize>32</BitSize>
+                <BitOffs>1440</BitOffs>
+                <Properties>
+                    <Property>
+                        <Name>plcAttribute_pytmc</Name>
+                        <Value>pv: MessageID
         io: i
         field: DESC TwinCAT Message ID</Value>
-					</Property>
-				</Properties>
-			</SubItem>
-			<SubItem>
-				<Name>event_class</Name>
-				<Type GUID="{18071995-0000-0000-0000-000100000050}">STRING(80)</Type>
-				<BitSize>648</BitSize>
-				<BitOffs>1472</BitOffs>
-				<Properties>
-					<Property>
-						<Name>plcAttribute_pytmc</Name>
-						<Value>pv: EventClass
+                    </Property>
+                </Properties>
+            </SubItem>
+            <SubItem>
+                <Name>event_class</Name>
+                <Type GUID="{18071995-0000-0000-0000-000100000050}">STRING(80)</Type>
+                <BitSize>648</BitSize>
+                <BitOffs>1472</BitOffs>
+                <Properties>
+                    <Property>
+                        <Name>plcAttribute_pytmc</Name>
+                        <Value>pv: EventClass
         io: i
         field: DESC TwinCAT Event class</Value>
-					</Property>
-				</Properties>
-			</SubItem>
-			<SubItem>
-				<Name>msg</Name>
-				<Type GUID="{18071995-0000-0000-0000-0001000000FF}">STRING(255)</Type>
-				<BitSize>2048</BitSize>
-				<BitOffs>2120</BitOffs>
-				<Properties>
-					<Property>
-						<Name>plcAttribute_pytmc</Name>
-						<Value>pv: Message
+                    </Property>
+                </Properties>
+            </SubItem>
+            <SubItem>
+                <Name>msg</Name>
+                <Type GUID="{18071995-0000-0000-0000-0001000000FF}">STRING(255)</Type>
+                <BitSize>2048</BitSize>
+                <BitOffs>2120</BitOffs>
+                <Properties>
+                    <Property>
+                        <Name>plcAttribute_pytmc</Name>
+                        <Value>pv: Message
         io: i</Value>
-					</Property>
-				</Properties>
-			</SubItem>
-			<SubItem>
-				<Name>source</Name>
-				<Type GUID="{18071995-0000-0000-0000-0001000000FF}">STRING(255)</Type>
-				<Comment>
-					<![CDATA[This is actually: T_MaxString
+                    </Property>
+                </Properties>
+            </SubItem>
+            <SubItem>
+                <Name>source</Name>
+                <Type GUID="{18071995-0000-0000-0000-0001000000FF}">STRING(255)</Type>
+                <Comment>
+                    <![CDATA[This is actually: T_MaxString
  which has been expanded due to requirements for pinning global data types.]]>
-				</Comment>
-				<BitSize>2048</BitSize>
-				<BitOffs>4168</BitOffs>
-				<Properties>
-					<Property>
-						<Name>plcAttribute_pytmc</Name>
-						<Value>pv: Source
+                </Comment>
+                <BitSize>2048</BitSize>
+                <BitOffs>4168</BitOffs>
+                <Properties>
+                    <Property>
+                        <Name>plcAttribute_pytmc</Name>
+                        <Value>pv: Source
         io: i</Value>
-					</Property>
-				</Properties>
-			</SubItem>
-			<SubItem>
-				<Name>event_type</Name>
-				<Type GUID="{A81A482A-E7CE-49D8-A4DD-8280773A6946}">E_LogEventType</Type>
-				<Comment>
-					<![CDATA[This is actually: STRING(Tc3_EventLogger.ParameterList.cSourceNameSize - 1)
+                    </Property>
+                </Properties>
+            </SubItem>
+            <SubItem>
+                <Name>event_type</Name>
+                <Type GUID="{A81A482A-E7CE-49D8-A4DD-8280773A6946}">E_LogEventType</Type>
+                <Comment>
+                    <![CDATA[This is actually: STRING(Tc3_EventLogger.ParameterList.cSourceNameSize - 1)
  which has been expanded due to requirements for pinning global data types.]]>
-				</Comment>
-				<BitSize>16</BitSize>
-				<BitOffs>6224</BitOffs>
-				<Properties>
-					<Property>
-						<Name>plcAttribute_pytmc</Name>
-						<Value>pv: EventType
+                </Comment>
+                <BitSize>16</BitSize>
+                <BitOffs>6224</BitOffs>
+                <Properties>
+                    <Property>
+                        <Name>plcAttribute_pytmc</Name>
+                        <Value>pv: EventType
         io: i
         field: DESC The event type</Value>
-					</Property>
-				</Properties>
-			</SubItem>
-			<SubItem>
-				<Name>json</Name>
-				<Type GUID="{18071995-0000-0000-0000-000100002710}">STRING(10000)</Type>
-				<BitSize>80008</BitSize>
-				<BitOffs>6240</BitOffs>
-				<Properties>
-					<Property>
-						<Name>plcAttribute_pytmc</Name>
-						<Value>pv: MessageJSON
+                    </Property>
+                </Properties>
+            </SubItem>
+            <SubItem>
+                <Name>json</Name>
+                <Type GUID="{18071995-0000-0000-0000-000100002710}">STRING(10000)</Type>
+                <BitSize>80008</BitSize>
+                <BitOffs>6240</BitOffs>
+                <Properties>
+                    <Property>
+                        <Name>plcAttribute_pytmc</Name>
+                        <Value>pv: MessageJSON
         io: i
         field: DESC Metadata with the message</Value>
-					</Property>
-				</Properties>
-			</SubItem>
-			<Hides>
-				<Hide GUID="{91686BB0-81A3-47A0-8E20-449823CCE7F0}"/>
-			</Hides>
-		</DataType>
-		<DataType>
-			<Name GUID="{85DC3E7A-8ADA-435B-9479-25573909A7DB}" Namespace="AX5000" TcBaseType="true">E_AX5000_P_0275_ActiveFeedbackAndMemory</Name>
-			<BitSize>8</BitSize>
-			<BaseType GUID="{18071995-0000-0000-0000-000000000001}">BYTE</BaseType>
-			<EnumInfo>
-				<Text>
-					<![CDATA[EAX5000_P_0275_MEMORY_NONE]]>
-				</Text>
-				<Enum>0</Enum>
-			</EnumInfo>
-			<EnumInfo>
-				<Text>
-					<![CDATA[EAX5000_P_0275_FEEDBACK1_MEMORY_ENCODER]]>
-				</Text>
-				<Enum>1</Enum>
-			</EnumInfo>
-			<EnumInfo>
-				<Text>
-					<![CDATA[EAX5000_P_0275_FEEDBACK1_MEMORY_DRIVE]]>
-				</Text>
-				<Enum>2</Enum>
-			</EnumInfo>
-			<EnumInfo>
-				<Text>
-					<![CDATA[EAX5000_P_0275_FEEDBACK2_MEMORY_ENCODER]]>
-				</Text>
-				<Enum>8</Enum>
-			</EnumInfo>
-			<EnumInfo>
-				<Text>
-					<![CDATA[EAX5000_P_0275_FEEDBACK2_MEMORY_DRIVE]]>
-				</Text>
-				<Enum>16</Enum>
-			</EnumInfo>
-			<Hides>
-				<Hide GUID="{F1A82E04-2D76-4E5D-BB15-437337214D25}"/>
-			</Hides>
-		</DataType>
-		<DataType>
-			<Name GUID="{D7D16A25-71D5-48E0-882D-56AB4D826BC2}" Namespace="AX5000" PersistentType="true">ST_AX5000_P_0275</Name>
-			<BitSize>16</BitSize>
-			<SubItem>
-				<Name>ActiveFeedbackAndMemory</Name>
-				<Type GUID="{85DC3E7A-8ADA-435B-9479-25573909A7DB}" Namespace="AX5000">E_AX5000_P_0275_ActiveFeedbackAndMemory</Type>
-				<BitSize>8</BitSize>
-				<BitOffs>0</BitOffs>
-			</SubItem>
-			<SubItem>
-				<Name>InitializationErrorBehavior</Name>
-				<Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-				<BitSize>1</BitSize>
-				<BitOffs>8</BitOffs>
-			</SubItem>
-			<Hides>
-				<Hide GUID="{0D1A14D3-018F-4F48-88A7-90B490A317B5}"/>
-				<Hide GUID="{43B3CFF1-FA94-4CC1-8B03-C73EF940373B}"/>
-				<Hide GUID="{81B09CD0-943C-4070-AA5B-0A6818251CEB}"/>
-				<Hide GUID="{B6598B95-DC2C-454C-9B12-DE628B32D897}"/>
-			</Hides>
-		</DataType>
-	</DataTypes>
-	<Project ProjectGUID="{9AC02CD1-4FA4-49DE-BC09-848126C612E3}" TargetNetId="5.40.55.128.1.1" ShowHideConfigurations="#x6">
-		<System>
-			<Licenses>
-				<Target>
-					<ManualSelect>{3EBB9639-5FF3-42B6-8847-35C70DC013C8}</ManualSelect>
-				</Target>
-			</Licenses>
-			<Tasks>
-				<Task Id="3" Priority="1" CycleTime="100000" AmsPort="350" AdtTasks="true">
-					<Name>Task 3</Name>
-				</Task>
-			</Tasks>
-		</System>
-		<Plc>
-			<Project GUID="{DF4CAFE9-8807-49B7-953A-22D467A15EF7}" Name="LCLSGeneral" PrjFilePath="LCLSGeneral\LCLSGeneral.plcproj" TmcFilePath="LCLSGeneral\LCLSGeneral.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e">
-				<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="LCLSGeneral\LCLSGeneral.tmc">
-					<Name>LCLSGeneral Instance</Name>
-					<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
-					<Vars VarGrpType="1">
-						<Name>Task_3 Inputs</Name>
-						<Var>
-							<Name>DefaultGlobals.stSys.I_EcatMaster1</Name>
-							<Comment>
-								<![CDATA[ AMS Net ID used for FB_EcatDiag, among others ]]>
-							</Comment>
-							<Type GUID="{18071995-0000-0000-0000-000000000041}">AMSNETID</Type>
-						</Var>
-					</Vars>
-					<TaskPouOids>
-						<TaskPouOid Prio="1" OTCID="#x08502001"/>
-					</TaskPouOids>
-				</Instance>
-			</Project>
-		</Plc>
-	</Project>
+                    </Property>
+                </Properties>
+            </SubItem>
+            <Hides>
+                <Hide GUID="{91686BB0-81A3-47A0-8E20-449823CCE7F0}"/>
+            </Hides>
+        </DataType>
+        <DataType>
+            <Name GUID="{85DC3E7A-8ADA-435B-9479-25573909A7DB}" Namespace="AX5000" TcBaseType="true">E_AX5000_P_0275_ActiveFeedbackAndMemory</Name>
+            <BitSize>8</BitSize>
+            <BaseType GUID="{18071995-0000-0000-0000-000000000001}">BYTE</BaseType>
+            <EnumInfo>
+                <Text>
+                    <![CDATA[EAX5000_P_0275_MEMORY_NONE]]>
+                </Text>
+                <Enum>0</Enum>
+            </EnumInfo>
+            <EnumInfo>
+                <Text>
+                    <![CDATA[EAX5000_P_0275_FEEDBACK1_MEMORY_ENCODER]]>
+                </Text>
+                <Enum>1</Enum>
+            </EnumInfo>
+            <EnumInfo>
+                <Text>
+                    <![CDATA[EAX5000_P_0275_FEEDBACK1_MEMORY_DRIVE]]>
+                </Text>
+                <Enum>2</Enum>
+            </EnumInfo>
+            <EnumInfo>
+                <Text>
+                    <![CDATA[EAX5000_P_0275_FEEDBACK2_MEMORY_ENCODER]]>
+                </Text>
+                <Enum>8</Enum>
+            </EnumInfo>
+            <EnumInfo>
+                <Text>
+                    <![CDATA[EAX5000_P_0275_FEEDBACK2_MEMORY_DRIVE]]>
+                </Text>
+                <Enum>16</Enum>
+            </EnumInfo>
+            <Hides>
+                <Hide GUID="{F1A82E04-2D76-4E5D-BB15-437337214D25}"/>
+            </Hides>
+        </DataType>
+        <DataType>
+            <Name GUID="{D7D16A25-71D5-48E0-882D-56AB4D826BC2}" Namespace="AX5000" PersistentType="true">ST_AX5000_P_0275</Name>
+            <BitSize>16</BitSize>
+            <SubItem>
+                <Name>ActiveFeedbackAndMemory</Name>
+                <Type GUID="{85DC3E7A-8ADA-435B-9479-25573909A7DB}" Namespace="AX5000">E_AX5000_P_0275_ActiveFeedbackAndMemory</Type>
+                <BitSize>8</BitSize>
+                <BitOffs>0</BitOffs>
+            </SubItem>
+            <SubItem>
+                <Name>InitializationErrorBehavior</Name>
+                <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+                <BitSize>1</BitSize>
+                <BitOffs>8</BitOffs>
+            </SubItem>
+            <Hides>
+                <Hide GUID="{0D1A14D3-018F-4F48-88A7-90B490A317B5}"/>
+                <Hide GUID="{43B3CFF1-FA94-4CC1-8B03-C73EF940373B}"/>
+                <Hide GUID="{81B09CD0-943C-4070-AA5B-0A6818251CEB}"/>
+                <Hide GUID="{B6598B95-DC2C-454C-9B12-DE628B32D897}"/>
+            </Hides>
+        </DataType>
+    </DataTypes>
+    <Project ProjectGUID="{9AC02CD1-4FA4-49DE-BC09-848126C612E3}" TargetNetId="172.21.148.145.1.1" ShowHideConfigurations="#x6">
+        <System>
+            <Licenses>
+                <Target>
+                    <ManualSelect>{3EBB9639-5FF3-42B6-8847-35C70DC013C8}</ManualSelect>
+                </Target>
+            </Licenses>
+            <Tasks>
+                <Task Id="3" Priority="1" CycleTime="100000" AmsPort="350" AdtTasks="true">
+                    <Name>Task 3</Name>
+                </Task>
+            </Tasks>
+        </System>
+        <Plc>
+            <Project GUID="{DF4CAFE9-8807-49B7-953A-22D467A15EF7}" Name="LCLSGeneral" PrjFilePath="LCLSGeneral\LCLSGeneral.plcproj" TmcFilePath="LCLSGeneral\LCLSGeneral.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e">
+                <Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="LCLSGeneral\LCLSGeneral.tmc">
+                    <Name>LCLSGeneral Instance</Name>
+                    <CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
+                    <Vars VarGrpType="1">
+                        <Name>Task_3 Inputs</Name>
+                        <Var>
+                            <Name>DefaultGlobals.stSys.I_EcatMaster1</Name>
+                            <Comment>
+                                <![CDATA[ AMS Net ID used for FB_EcatDiag, among others ]]>
+                            </Comment>
+                            <Type GUID="{18071995-0000-0000-0000-000000000041}">AMSNETID</Type>
+                        </Var>
+                    </Vars>
+                    <TaskPouOids>
+                        <TaskPouOid Prio="1" OTCID="#x08502001"/>
+                    </TaskPouOids>
+                </Instance>
+            </Project>
+        </Plc>
+    </Project>
 </TcSmProject>

--- a/LCLSGeneral/LCLSGeneral.tsproj
+++ b/LCLSGeneral/LCLSGeneral.tsproj
@@ -1,373 +1,371 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <TcSmProject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4022.30">
-    <DataTypes>
-        <DataType>
-            <Name GUID="{18071995-0000-0000-0000-000000000041}" TcBaseType="true" HideSubItems="true" CName="AmsNetId">AMSNETID</Name>
-            <BitSize>48</BitSize>
-            <BaseType GUID="{18071995-0000-0000-0000-000000000001}">BYTE</BaseType>
-            <ArrayInfo>
-                <LBound>0</LBound>
-                <Elements>6</Elements>
-            </ArrayInfo>
-            <Format>
-                <Printf>%d.%d.%d.%d.%d.%d</Printf>
-                <Parameter>[0]</Parameter>
-                <Parameter>[1]</Parameter>
-                <Parameter>[2]</Parameter>
-                <Parameter>[3]</Parameter>
-                <Parameter>[4]</Parameter>
-                <Parameter>[5]</Parameter>
-            </Format>
-        </DataType>
-        <DataType>
-            <Name GUID="{A81A482A-E7CE-49D8-A4DD-8280773A6946}" PersistentType="true">E_LogEventType</Name>
-            <BitSize>16</BitSize>
-            <BaseType GUID="{18071995-0000-0000-0000-000000000006}">INT</BaseType>
-            <EnumInfo>
-                <Text>
-                    <![CDATA[ALARMCLEARED]]>
-                </Text>
-                <Enum>0</Enum>
-            </EnumInfo>
-            <EnumInfo>
-                <Text>
-                    <![CDATA[ALARMCONFIRMED]]>
-                </Text>
-                <Enum>1</Enum>
-            </EnumInfo>
-            <EnumInfo>
-                <Text>
-                    <![CDATA[ALARMRAISED]]>
-                </Text>
-                <Enum>2</Enum>
-            </EnumInfo>
-            <EnumInfo>
-                <Text>
-                    <![CDATA[MESSAGESENT]]>
-                </Text>
-                <Enum>3</Enum>
-            </EnumInfo>
-            <Properties>
-                <Property>
-                    <Name>plcAttribute_qualified_only</Name>
-                </Property>
-                <Property>
-                    <Name>plcAttribute_strict</Name>
-                </Property>
-            </Properties>
-        </DataType>
-        <DataType>
-            <Name GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}" TcBaseType="true" CName="TcEventSeverity" RemovableEnumPrefix="TCEVENTSEVERITY_">TcEventSeverity</Name>
-            <BitSize>16</BitSize>
-            <BaseType GUID="{18071995-0000-0000-0000-000000000006}">INT</BaseType>
-            <EnumInfo>
-                <Text>
-                    <![CDATA[TCEVENTSEVERITY_Verbose]]>
-                </Text>
-                <Enum>0</Enum>
-            </EnumInfo>
-            <EnumInfo>
-                <Text>
-                    <![CDATA[TCEVENTSEVERITY_Info]]>
-                </Text>
-                <Enum>1</Enum>
-            </EnumInfo>
-            <EnumInfo>
-                <Text>
-                    <![CDATA[TCEVENTSEVERITY_Warning]]>
-                </Text>
-                <Enum>2</Enum>
-            </EnumInfo>
-            <EnumInfo>
-                <Text>
-                    <![CDATA[TCEVENTSEVERITY_Error]]>
-                </Text>
-                <Enum>3</Enum>
-            </EnumInfo>
-            <EnumInfo>
-                <Text>
-                    <![CDATA[TCEVENTSEVERITY_Critical]]>
-                </Text>
-                <Enum>4</Enum>
-            </EnumInfo>
-            <Properties>
-                <Property>
-                    <Name>plcAttribute_qualified_only</Name>
-                </Property>
-                <Property>
-                    <Name>plcAttribute_strict</Name>
-                </Property>
-            </Properties>
-            <Hides>
-                <Hide GUID="{777FF09F-0B00-4AF2-BD7C-C1E2CE4A0947}"/>
-                <Hide GUID="{EC3C119D-4FEC-4197-96FB-DAE1B7C403FB}"/>
-            </Hides>
-        </DataType>
-        <DataType>
-            <Name GUID="{32DBDCFB-9DE9-4726-B195-4528904D5F40}" PersistentType="true">ST_LoggingEventInfo</Name>
-            <BitSize>86272</BitSize>
-            <SubItem>
-                <Name>schema</Name>
-                <Type GUID="{18071995-0000-0000-0000-000100000050}">STRING(80)</Type>
-                <Comment>
-                    <![CDATA[ 
-        Message or Alarm{Cleared,Confirmed,Raised} event information
+	<DataTypes>
+		<DataType>
+			<Name GUID="{18071995-0000-0000-0000-000000000041}" TcBaseType="true" HideSubItems="true" CName="AmsNetId">AMSNETID</Name>
+			<BitSize>48</BitSize>
+			<BaseType GUID="{18071995-0000-0000-0000-000000000001}">BYTE</BaseType>
+			<ArrayInfo>
+				<LBound>0</LBound>
+				<Elements>6</Elements>
+			</ArrayInfo>
+			<Format>
+				<Printf>%d.%d.%d.%d.%d.%d</Printf>
+				<Parameter>[0]</Parameter>
+				<Parameter>[1]</Parameter>
+				<Parameter>[2]</Parameter>
+				<Parameter>[3]</Parameter>
+				<Parameter>[4]</Parameter>
+				<Parameter>[5]</Parameter>
+			</Format>
+		</DataType>
+		<DataType>
+			<Name GUID="{A81A482A-E7CE-49D8-A4DD-8280773A6946}" PersistentType="true">E_LogEventType</Name>
+			<BitSize>16</BitSize>
+			<BaseType GUID="{18071995-0000-0000-0000-000000000006}">INT</BaseType>
+			<EnumInfo>
+				<Text>
+					<![CDATA[ALARMCLEARED]]>
+				</Text>
+				<Enum>0</Enum>
+			</EnumInfo>
+			<EnumInfo>
+				<Text>
+					<![CDATA[ALARMCONFIRMED]]>
+				</Text>
+				<Enum>1</Enum>
+			</EnumInfo>
+			<EnumInfo>
+				<Text>
+					<![CDATA[ALARMRAISED]]>
+				</Text>
+				<Enum>2</Enum>
+			</EnumInfo>
+			<EnumInfo>
+				<Text>
+					<![CDATA[MESSAGESENT]]>
+				</Text>
+				<Enum>3</Enum>
+			</EnumInfo>
+			<Properties>
+				<Property>
+					<Name>plcAttribute_qualified_only</Name>
+				</Property>
+				<Property>
+					<Name>plcAttribute_strict</Name>
+				</Property>
+			</Properties>
+		</DataType>
+		<DataType>
+			<Name GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}" TcBaseType="true" CName="TcEventSeverity" RemovableEnumPrefix="TCEVENTSEVERITY_">TcEventSeverity</Name>
+			<BitSize>16</BitSize>
+			<BaseType GUID="{18071995-0000-0000-0000-000000000006}">INT</BaseType>
+			<EnumInfo>
+				<Text>
+					<![CDATA[TCEVENTSEVERITY_Verbose]]>
+				</Text>
+				<Enum>0</Enum>
+			</EnumInfo>
+			<EnumInfo>
+				<Text>
+					<![CDATA[TCEVENTSEVERITY_Info]]>
+				</Text>
+				<Enum>1</Enum>
+			</EnumInfo>
+			<EnumInfo>
+				<Text>
+					<![CDATA[TCEVENTSEVERITY_Warning]]>
+				</Text>
+				<Enum>2</Enum>
+			</EnumInfo>
+			<EnumInfo>
+				<Text>
+					<![CDATA[TCEVENTSEVERITY_Error]]>
+				</Text>
+				<Enum>3</Enum>
+			</EnumInfo>
+			<EnumInfo>
+				<Text>
+					<![CDATA[TCEVENTSEVERITY_Critical]]>
+				</Text>
+				<Enum>4</Enum>
+			</EnumInfo>
+			<Properties>
+				<Property>
+					<Name>plcAttribute_qualified_only</Name>
+				</Property>
+				<Property>
+					<Name>plcAttribute_strict</Name>
+				</Property>
+			</Properties>
+			<Hides>
+				<Hide GUID="{777FF09F-0B00-4AF2-BD7C-C1E2CE4A0947}"/>
+				<Hide GUID="{EC3C119D-4FEC-4197-96FB-DAE1B7C403FB}"/>
+			</Hides>
+		</DataType>
+		<DataType>
+			<Name GUID="{32DBDCFB-9DE9-4726-B195-4528904D5F40}" PersistentType="true">ST_LoggingEventInfo</Name>
+			<BitSize>86272</BitSize>
+			<SubItem>
+				<Name>schema</Name>
+				<Type GUID="{18071995-0000-0000-0000-000100000050}">STRING(80)</Type>
+				<Comment>
+					<![CDATA[Message or Alarm{Cleared,Confirmed,Raised} event information
 
         Note that elements here do not follow the usual Hungarian notation / 
         variable-type-prefixing naming convention due to the member names being
-        used directly in the generation of the JSON document.
-    ]]>
-                </Comment>
-                <BitSize>648</BitSize>
-                <BitOffs>0</BitOffs>
-                <Default>
-                    <String>
-                        <![CDATA[twincat-event-0]]>
-                    </String>
-                </Default>
-                <Properties>
-                    <Property>
-                        <Name>plcAttribute_pytmc</Name>
-                        <Value>pv: Schema
+        used directly in the generation of the JSON document.]]>
+				</Comment>
+				<BitSize>648</BitSize>
+				<BitOffs>0</BitOffs>
+				<Default>
+					<String>
+						<![CDATA[twincat-event-0]]>
+					</String>
+				</Default>
+				<Properties>
+					<Property>
+						<Name>plcAttribute_pytmc</Name>
+						<Value>pv: Schema
         io: i
         field: DESC Schema string</Value>
-                    </Property>
-                </Properties>
-            </SubItem>
-            <SubItem>
-                <Name>ts</Name>
-                <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
-                <BitSize>64</BitSize>
-                <BitOffs>704</BitOffs>
-                <Properties>
-                    <Property>
-                        <Name>plcAttribute_pytmc</Name>
-                        <Value>pv: Timestamp 
+					</Property>
+				</Properties>
+			</SubItem>
+			<SubItem>
+				<Name>ts</Name>
+				<Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+				<BitSize>64</BitSize>
+				<BitOffs>704</BitOffs>
+				<Properties>
+					<Property>
+						<Name>plcAttribute_pytmc</Name>
+						<Value>pv: Timestamp 
         io: i
         field: DESC Unix timestamp</Value>
-                    </Property>
-                </Properties>
-            </SubItem>
-            <SubItem>
-                <Name>plc</Name>
-                <Type GUID="{18071995-0000-0000-0000-000100000050}">STRING(80)</Type>
-                <BitSize>648</BitSize>
-                <BitOffs>768</BitOffs>
-                <Properties>
-                    <Property>
-                        <Name>plcAttribute_pytmc</Name>
-                        <Value>pv: Hostname 
+					</Property>
+				</Properties>
+			</SubItem>
+			<SubItem>
+				<Name>plc</Name>
+				<Type GUID="{18071995-0000-0000-0000-000100000050}">STRING(80)</Type>
+				<BitSize>648</BitSize>
+				<BitOffs>768</BitOffs>
+				<Properties>
+					<Property>
+						<Name>plcAttribute_pytmc</Name>
+						<Value>pv: Hostname 
         io: i
         field: DESC PLC Hostname</Value>
-                    </Property>
-                </Properties>
-            </SubItem>
-            <SubItem>
-                <Name>severity</Name>
-                <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
-                <BitSize>16</BitSize>
-                <BitOffs>1424</BitOffs>
-                <Properties>
-                    <Property>
-                        <Name>plcAttribute_pytmc</Name>
-                        <Value>pv: Severity
+					</Property>
+				</Properties>
+			</SubItem>
+			<SubItem>
+				<Name>severity</Name>
+				<Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
+				<BitSize>16</BitSize>
+				<BitOffs>1424</BitOffs>
+				<Properties>
+					<Property>
+						<Name>plcAttribute_pytmc</Name>
+						<Value>pv: Severity
         io: i
         field: DESC TcEventSeverity	
         field: ZRST Verbose
         field: ONST Info
         field: TWST Warning
         field: THST Error</Value>
-                    </Property>
-                </Properties>
-            </SubItem>
-            <SubItem>
-                <Name>id</Name>
-                <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-                <BitSize>32</BitSize>
-                <BitOffs>1440</BitOffs>
-                <Properties>
-                    <Property>
-                        <Name>plcAttribute_pytmc</Name>
-                        <Value>pv: MessageID
+					</Property>
+				</Properties>
+			</SubItem>
+			<SubItem>
+				<Name>id</Name>
+				<Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+				<BitSize>32</BitSize>
+				<BitOffs>1440</BitOffs>
+				<Properties>
+					<Property>
+						<Name>plcAttribute_pytmc</Name>
+						<Value>pv: MessageID
         io: i
         field: DESC TwinCAT Message ID</Value>
-                    </Property>
-                </Properties>
-            </SubItem>
-            <SubItem>
-                <Name>event_class</Name>
-                <Type GUID="{18071995-0000-0000-0000-000100000050}">STRING(80)</Type>
-                <BitSize>648</BitSize>
-                <BitOffs>1472</BitOffs>
-                <Properties>
-                    <Property>
-                        <Name>plcAttribute_pytmc</Name>
-                        <Value>pv: EventClass
+					</Property>
+				</Properties>
+			</SubItem>
+			<SubItem>
+				<Name>event_class</Name>
+				<Type GUID="{18071995-0000-0000-0000-000100000050}">STRING(80)</Type>
+				<BitSize>648</BitSize>
+				<BitOffs>1472</BitOffs>
+				<Properties>
+					<Property>
+						<Name>plcAttribute_pytmc</Name>
+						<Value>pv: EventClass
         io: i
         field: DESC TwinCAT Event class</Value>
-                    </Property>
-                </Properties>
-            </SubItem>
-            <SubItem>
-                <Name>msg</Name>
-                <Type GUID="{18071995-0000-0000-0000-0001000000FF}">STRING(255)</Type>
-                <BitSize>2048</BitSize>
-                <BitOffs>2120</BitOffs>
-                <Properties>
-                    <Property>
-                        <Name>plcAttribute_pytmc</Name>
-                        <Value>pv: Message
+					</Property>
+				</Properties>
+			</SubItem>
+			<SubItem>
+				<Name>msg</Name>
+				<Type GUID="{18071995-0000-0000-0000-0001000000FF}">STRING(255)</Type>
+				<BitSize>2048</BitSize>
+				<BitOffs>2120</BitOffs>
+				<Properties>
+					<Property>
+						<Name>plcAttribute_pytmc</Name>
+						<Value>pv: Message
         io: i</Value>
-                    </Property>
-                </Properties>
-            </SubItem>
-            <SubItem>
-                <Name>source</Name>
-                <Type GUID="{18071995-0000-0000-0000-0001000000FF}">STRING(255)</Type>
-                <Comment>
-                    <![CDATA[ This is actually: T_MaxString
+					</Property>
+				</Properties>
+			</SubItem>
+			<SubItem>
+				<Name>source</Name>
+				<Type GUID="{18071995-0000-0000-0000-0001000000FF}">STRING(255)</Type>
+				<Comment>
+					<![CDATA[This is actually: T_MaxString
  which has been expanded due to requirements for pinning global data types.]]>
-                </Comment>
-                <BitSize>2048</BitSize>
-                <BitOffs>4168</BitOffs>
-                <Properties>
-                    <Property>
-                        <Name>plcAttribute_pytmc</Name>
-                        <Value>pv: Source
+				</Comment>
+				<BitSize>2048</BitSize>
+				<BitOffs>4168</BitOffs>
+				<Properties>
+					<Property>
+						<Name>plcAttribute_pytmc</Name>
+						<Value>pv: Source
         io: i</Value>
-                    </Property>
-                </Properties>
-            </SubItem>
-            <SubItem>
-                <Name>event_type</Name>
-                <Type GUID="{A81A482A-E7CE-49D8-A4DD-8280773A6946}">E_LogEventType</Type>
-                <Comment>
-                    <![CDATA[ This is actually: STRING(Tc3_EventLogger.ParameterList.cSourceNameSize - 1)
+					</Property>
+				</Properties>
+			</SubItem>
+			<SubItem>
+				<Name>event_type</Name>
+				<Type GUID="{A81A482A-E7CE-49D8-A4DD-8280773A6946}">E_LogEventType</Type>
+				<Comment>
+					<![CDATA[This is actually: STRING(Tc3_EventLogger.ParameterList.cSourceNameSize - 1)
  which has been expanded due to requirements for pinning global data types.]]>
-                </Comment>
-                <BitSize>16</BitSize>
-                <BitOffs>6224</BitOffs>
-                <Properties>
-                    <Property>
-                        <Name>plcAttribute_pytmc</Name>
-                        <Value>pv: EventType
+				</Comment>
+				<BitSize>16</BitSize>
+				<BitOffs>6224</BitOffs>
+				<Properties>
+					<Property>
+						<Name>plcAttribute_pytmc</Name>
+						<Value>pv: EventType
         io: i
         field: DESC The event type</Value>
-                    </Property>
-                </Properties>
-            </SubItem>
-            <SubItem>
-                <Name>json</Name>
-                <Type GUID="{18071995-0000-0000-0000-000100002710}">STRING(10000)</Type>
-                <BitSize>80008</BitSize>
-                <BitOffs>6240</BitOffs>
-                <Properties>
-                    <Property>
-                        <Name>plcAttribute_pytmc</Name>
-                        <Value>pv: MessageJSON
+					</Property>
+				</Properties>
+			</SubItem>
+			<SubItem>
+				<Name>json</Name>
+				<Type GUID="{18071995-0000-0000-0000-000100002710}">STRING(10000)</Type>
+				<BitSize>80008</BitSize>
+				<BitOffs>6240</BitOffs>
+				<Properties>
+					<Property>
+						<Name>plcAttribute_pytmc</Name>
+						<Value>pv: MessageJSON
         io: i
         field: DESC Metadata with the message</Value>
-                    </Property>
-                </Properties>
-            </SubItem>
-            <Hides>
-                <Hide GUID="{91686BB0-81A3-47A0-8E20-449823CCE7F0}"/>
-            </Hides>
-        </DataType>
-        <DataType>
-            <Name GUID="{85DC3E7A-8ADA-435B-9479-25573909A7DB}" Namespace="AX5000" TcBaseType="true">E_AX5000_P_0275_ActiveFeedbackAndMemory</Name>
-            <BitSize>8</BitSize>
-            <BaseType GUID="{18071995-0000-0000-0000-000000000001}">BYTE</BaseType>
-            <EnumInfo>
-                <Text>
-                    <![CDATA[EAX5000_P_0275_MEMORY_NONE]]>
-                </Text>
-                <Enum>0</Enum>
-            </EnumInfo>
-            <EnumInfo>
-                <Text>
-                    <![CDATA[EAX5000_P_0275_FEEDBACK1_MEMORY_ENCODER]]>
-                </Text>
-                <Enum>1</Enum>
-            </EnumInfo>
-            <EnumInfo>
-                <Text>
-                    <![CDATA[EAX5000_P_0275_FEEDBACK1_MEMORY_DRIVE]]>
-                </Text>
-                <Enum>2</Enum>
-            </EnumInfo>
-            <EnumInfo>
-                <Text>
-                    <![CDATA[EAX5000_P_0275_FEEDBACK2_MEMORY_ENCODER]]>
-                </Text>
-                <Enum>8</Enum>
-            </EnumInfo>
-            <EnumInfo>
-                <Text>
-                    <![CDATA[EAX5000_P_0275_FEEDBACK2_MEMORY_DRIVE]]>
-                </Text>
-                <Enum>16</Enum>
-            </EnumInfo>
-            <Hides>
-                <Hide GUID="{F1A82E04-2D76-4E5D-BB15-437337214D25}"/>
-            </Hides>
-        </DataType>
-        <DataType>
-            <Name GUID="{D7D16A25-71D5-48E0-882D-56AB4D826BC2}" Namespace="AX5000" PersistentType="true">ST_AX5000_P_0275</Name>
-            <BitSize>16</BitSize>
-            <SubItem>
-                <Name>ActiveFeedbackAndMemory</Name>
-                <Type GUID="{85DC3E7A-8ADA-435B-9479-25573909A7DB}" Namespace="AX5000">E_AX5000_P_0275_ActiveFeedbackAndMemory</Type>
-                <BitSize>8</BitSize>
-                <BitOffs>0</BitOffs>
-            </SubItem>
-            <SubItem>
-                <Name>InitializationErrorBehavior</Name>
-                <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-                <BitSize>1</BitSize>
-                <BitOffs>8</BitOffs>
-            </SubItem>
-            <Hides>
-                <Hide GUID="{0D1A14D3-018F-4F48-88A7-90B490A317B5}"/>
-                <Hide GUID="{43B3CFF1-FA94-4CC1-8B03-C73EF940373B}"/>
-                <Hide GUID="{81B09CD0-943C-4070-AA5B-0A6818251CEB}"/>
-                <Hide GUID="{B6598B95-DC2C-454C-9B12-DE628B32D897}"/>
-            </Hides>
-        </DataType>
-    </DataTypes>
-    <Project ProjectGUID="{9AC02CD1-4FA4-49DE-BC09-848126C612E3}" TargetNetId="5.40.55.128.1.1" ShowHideConfigurations="#x6">
-        <System>
-            <Licenses>
-                <Target>
-                    <ManualSelect>{3EBB9639-5FF3-42B6-8847-35C70DC013C8}</ManualSelect>
-                </Target>
-            </Licenses>
-            <Tasks>
-                <Task Id="3" Priority="1" CycleTime="100000" AmsPort="350" AdtTasks="true">
-                    <Name>Task 3</Name>
-                </Task>
-            </Tasks>
-        </System>
-        <Plc>
-            <Project GUID="{DF4CAFE9-8807-49B7-953A-22D467A15EF7}" Name="LCLSGeneral" PrjFilePath="LCLSGeneral\LCLSGeneral.plcproj" TmcFilePath="LCLSGeneral\LCLSGeneral.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e">
-                <Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="LCLSGeneral\LCLSGeneral.tmc">
-                    <Name>LCLSGeneral Instance</Name>
-                    <CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
-                    <Vars VarGrpType="1">
-                        <Name>Task_3 Inputs</Name>
-                        <Var>
-                            <Name>DefaultGlobals.stSys.I_EcatMaster1</Name>
-                            <Comment>
-                                <![CDATA[ AMS Net ID used for FB_EcatDiag, among others ]]>
-                            </Comment>
-                            <Type GUID="{18071995-0000-0000-0000-000000000041}">AMSNETID</Type>
-                        </Var>
-                    </Vars>
-                    <TaskPouOids>
-                        <TaskPouOid Prio="1" OTCID="#x08502001"/>
-                    </TaskPouOids>
-                </Instance>
-            </Project>
-        </Plc>
-    </Project>
+					</Property>
+				</Properties>
+			</SubItem>
+			<Hides>
+				<Hide GUID="{91686BB0-81A3-47A0-8E20-449823CCE7F0}"/>
+			</Hides>
+		</DataType>
+		<DataType>
+			<Name GUID="{85DC3E7A-8ADA-435B-9479-25573909A7DB}" Namespace="AX5000" TcBaseType="true">E_AX5000_P_0275_ActiveFeedbackAndMemory</Name>
+			<BitSize>8</BitSize>
+			<BaseType GUID="{18071995-0000-0000-0000-000000000001}">BYTE</BaseType>
+			<EnumInfo>
+				<Text>
+					<![CDATA[EAX5000_P_0275_MEMORY_NONE]]>
+				</Text>
+				<Enum>0</Enum>
+			</EnumInfo>
+			<EnumInfo>
+				<Text>
+					<![CDATA[EAX5000_P_0275_FEEDBACK1_MEMORY_ENCODER]]>
+				</Text>
+				<Enum>1</Enum>
+			</EnumInfo>
+			<EnumInfo>
+				<Text>
+					<![CDATA[EAX5000_P_0275_FEEDBACK1_MEMORY_DRIVE]]>
+				</Text>
+				<Enum>2</Enum>
+			</EnumInfo>
+			<EnumInfo>
+				<Text>
+					<![CDATA[EAX5000_P_0275_FEEDBACK2_MEMORY_ENCODER]]>
+				</Text>
+				<Enum>8</Enum>
+			</EnumInfo>
+			<EnumInfo>
+				<Text>
+					<![CDATA[EAX5000_P_0275_FEEDBACK2_MEMORY_DRIVE]]>
+				</Text>
+				<Enum>16</Enum>
+			</EnumInfo>
+			<Hides>
+				<Hide GUID="{F1A82E04-2D76-4E5D-BB15-437337214D25}"/>
+			</Hides>
+		</DataType>
+		<DataType>
+			<Name GUID="{D7D16A25-71D5-48E0-882D-56AB4D826BC2}" Namespace="AX5000" PersistentType="true">ST_AX5000_P_0275</Name>
+			<BitSize>16</BitSize>
+			<SubItem>
+				<Name>ActiveFeedbackAndMemory</Name>
+				<Type GUID="{85DC3E7A-8ADA-435B-9479-25573909A7DB}" Namespace="AX5000">E_AX5000_P_0275_ActiveFeedbackAndMemory</Type>
+				<BitSize>8</BitSize>
+				<BitOffs>0</BitOffs>
+			</SubItem>
+			<SubItem>
+				<Name>InitializationErrorBehavior</Name>
+				<Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+				<BitSize>1</BitSize>
+				<BitOffs>8</BitOffs>
+			</SubItem>
+			<Hides>
+				<Hide GUID="{0D1A14D3-018F-4F48-88A7-90B490A317B5}"/>
+				<Hide GUID="{43B3CFF1-FA94-4CC1-8B03-C73EF940373B}"/>
+				<Hide GUID="{81B09CD0-943C-4070-AA5B-0A6818251CEB}"/>
+				<Hide GUID="{B6598B95-DC2C-454C-9B12-DE628B32D897}"/>
+			</Hides>
+		</DataType>
+	</DataTypes>
+	<Project ProjectGUID="{9AC02CD1-4FA4-49DE-BC09-848126C612E3}" TargetNetId="5.40.55.128.1.1" ShowHideConfigurations="#x6">
+		<System>
+			<Licenses>
+				<Target>
+					<ManualSelect>{3EBB9639-5FF3-42B6-8847-35C70DC013C8}</ManualSelect>
+				</Target>
+			</Licenses>
+			<Tasks>
+				<Task Id="3" Priority="1" CycleTime="100000" AmsPort="350" AdtTasks="true">
+					<Name>Task 3</Name>
+				</Task>
+			</Tasks>
+		</System>
+		<Plc>
+			<Project GUID="{DF4CAFE9-8807-49B7-953A-22D467A15EF7}" Name="LCLSGeneral" PrjFilePath="LCLSGeneral\LCLSGeneral.plcproj" TmcFilePath="LCLSGeneral\LCLSGeneral.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e">
+				<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="LCLSGeneral\LCLSGeneral.tmc">
+					<Name>LCLSGeneral Instance</Name>
+					<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
+					<Vars VarGrpType="1">
+						<Name>Task_3 Inputs</Name>
+						<Var>
+							<Name>DefaultGlobals.stSys.I_EcatMaster1</Name>
+							<Comment>
+								<![CDATA[ AMS Net ID used for FB_EcatDiag, among others ]]>
+							</Comment>
+							<Type GUID="{18071995-0000-0000-0000-000000000041}">AMSNETID</Type>
+						</Var>
+					</Vars>
+					<TaskPouOids>
+						<TaskPouOid Prio="1" OTCID="#x08502001"/>
+					</TaskPouOids>
+				</Instance>
+			</Project>
+		</Plc>
+	</Project>
 </TcSmProject>

--- a/LCLSGeneral/LCLSGeneral.tsproj
+++ b/LCLSGeneral/LCLSGeneral.tsproj
@@ -1,371 +1,371 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <TcSmProject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4022.30">
-    <DataTypes>
-        <DataType>
-            <Name GUID="{18071995-0000-0000-0000-000000000041}" TcBaseType="true" HideSubItems="true" CName="AmsNetId">AMSNETID</Name>
-            <BitSize>48</BitSize>
-            <BaseType GUID="{18071995-0000-0000-0000-000000000001}">BYTE</BaseType>
-            <ArrayInfo>
-                <LBound>0</LBound>
-                <Elements>6</Elements>
-            </ArrayInfo>
-            <Format>
-                <Printf>%d.%d.%d.%d.%d.%d</Printf>
-                <Parameter>[0]</Parameter>
-                <Parameter>[1]</Parameter>
-                <Parameter>[2]</Parameter>
-                <Parameter>[3]</Parameter>
-                <Parameter>[4]</Parameter>
-                <Parameter>[5]</Parameter>
-            </Format>
-        </DataType>
-        <DataType>
-            <Name GUID="{A81A482A-E7CE-49D8-A4DD-8280773A6946}" PersistentType="true">E_LogEventType</Name>
-            <BitSize>16</BitSize>
-            <BaseType GUID="{18071995-0000-0000-0000-000000000006}">INT</BaseType>
-            <EnumInfo>
-                <Text>
-                    <![CDATA[ALARMCLEARED]]>
-                </Text>
-                <Enum>0</Enum>
-            </EnumInfo>
-            <EnumInfo>
-                <Text>
-                    <![CDATA[ALARMCONFIRMED]]>
-                </Text>
-                <Enum>1</Enum>
-            </EnumInfo>
-            <EnumInfo>
-                <Text>
-                    <![CDATA[ALARMRAISED]]>
-                </Text>
-                <Enum>2</Enum>
-            </EnumInfo>
-            <EnumInfo>
-                <Text>
-                    <![CDATA[MESSAGESENT]]>
-                </Text>
-                <Enum>3</Enum>
-            </EnumInfo>
-            <Properties>
-                <Property>
-                    <Name>plcAttribute_qualified_only</Name>
-                </Property>
-                <Property>
-                    <Name>plcAttribute_strict</Name>
-                </Property>
-            </Properties>
-        </DataType>
-        <DataType>
-            <Name GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}" TcBaseType="true" CName="TcEventSeverity" RemovableEnumPrefix="TCEVENTSEVERITY_">TcEventSeverity</Name>
-            <BitSize>16</BitSize>
-            <BaseType GUID="{18071995-0000-0000-0000-000000000006}">INT</BaseType>
-            <EnumInfo>
-                <Text>
-                    <![CDATA[TCEVENTSEVERITY_Verbose]]>
-                </Text>
-                <Enum>0</Enum>
-            </EnumInfo>
-            <EnumInfo>
-                <Text>
-                    <![CDATA[TCEVENTSEVERITY_Info]]>
-                </Text>
-                <Enum>1</Enum>
-            </EnumInfo>
-            <EnumInfo>
-                <Text>
-                    <![CDATA[TCEVENTSEVERITY_Warning]]>
-                </Text>
-                <Enum>2</Enum>
-            </EnumInfo>
-            <EnumInfo>
-                <Text>
-                    <![CDATA[TCEVENTSEVERITY_Error]]>
-                </Text>
-                <Enum>3</Enum>
-            </EnumInfo>
-            <EnumInfo>
-                <Text>
-                    <![CDATA[TCEVENTSEVERITY_Critical]]>
-                </Text>
-                <Enum>4</Enum>
-            </EnumInfo>
-            <Properties>
-                <Property>
-                    <Name>plcAttribute_qualified_only</Name>
-                </Property>
-                <Property>
-                    <Name>plcAttribute_strict</Name>
-                </Property>
-            </Properties>
-            <Hides>
-                <Hide GUID="{777FF09F-0B00-4AF2-BD7C-C1E2CE4A0947}"/>
-                <Hide GUID="{EC3C119D-4FEC-4197-96FB-DAE1B7C403FB}"/>
-            </Hides>
-        </DataType>
-        <DataType>
-            <Name GUID="{32DBDCFB-9DE9-4726-B195-4528904D5F40}" PersistentType="true">ST_LoggingEventInfo</Name>
-            <BitSize>86272</BitSize>
-            <SubItem>
-                <Name>schema</Name>
-                <Type GUID="{18071995-0000-0000-0000-000100000050}">STRING(80)</Type>
-                <Comment>
-                    <![CDATA[Message or Alarm{Cleared,Confirmed,Raised} event information
+	<DataTypes>
+		<DataType>
+			<Name GUID="{18071995-0000-0000-0000-000000000041}" TcBaseType="true" HideSubItems="true" CName="AmsNetId">AMSNETID</Name>
+			<BitSize>48</BitSize>
+			<BaseType GUID="{18071995-0000-0000-0000-000000000001}">BYTE</BaseType>
+			<ArrayInfo>
+				<LBound>0</LBound>
+				<Elements>6</Elements>
+			</ArrayInfo>
+			<Format>
+				<Printf>%d.%d.%d.%d.%d.%d</Printf>
+				<Parameter>[0]</Parameter>
+				<Parameter>[1]</Parameter>
+				<Parameter>[2]</Parameter>
+				<Parameter>[3]</Parameter>
+				<Parameter>[4]</Parameter>
+				<Parameter>[5]</Parameter>
+			</Format>
+		</DataType>
+		<DataType>
+			<Name GUID="{A81A482A-E7CE-49D8-A4DD-8280773A6946}" PersistentType="true">E_LogEventType</Name>
+			<BitSize>16</BitSize>
+			<BaseType GUID="{18071995-0000-0000-0000-000000000006}">INT</BaseType>
+			<EnumInfo>
+				<Text>
+					<![CDATA[ALARMCLEARED]]>
+				</Text>
+				<Enum>0</Enum>
+			</EnumInfo>
+			<EnumInfo>
+				<Text>
+					<![CDATA[ALARMCONFIRMED]]>
+				</Text>
+				<Enum>1</Enum>
+			</EnumInfo>
+			<EnumInfo>
+				<Text>
+					<![CDATA[ALARMRAISED]]>
+				</Text>
+				<Enum>2</Enum>
+			</EnumInfo>
+			<EnumInfo>
+				<Text>
+					<![CDATA[MESSAGESENT]]>
+				</Text>
+				<Enum>3</Enum>
+			</EnumInfo>
+			<Properties>
+				<Property>
+					<Name>plcAttribute_qualified_only</Name>
+				</Property>
+				<Property>
+					<Name>plcAttribute_strict</Name>
+				</Property>
+			</Properties>
+		</DataType>
+		<DataType>
+			<Name GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}" TcBaseType="true" CName="TcEventSeverity" RemovableEnumPrefix="TCEVENTSEVERITY_">TcEventSeverity</Name>
+			<BitSize>16</BitSize>
+			<BaseType GUID="{18071995-0000-0000-0000-000000000006}">INT</BaseType>
+			<EnumInfo>
+				<Text>
+					<![CDATA[TCEVENTSEVERITY_Verbose]]>
+				</Text>
+				<Enum>0</Enum>
+			</EnumInfo>
+			<EnumInfo>
+				<Text>
+					<![CDATA[TCEVENTSEVERITY_Info]]>
+				</Text>
+				<Enum>1</Enum>
+			</EnumInfo>
+			<EnumInfo>
+				<Text>
+					<![CDATA[TCEVENTSEVERITY_Warning]]>
+				</Text>
+				<Enum>2</Enum>
+			</EnumInfo>
+			<EnumInfo>
+				<Text>
+					<![CDATA[TCEVENTSEVERITY_Error]]>
+				</Text>
+				<Enum>3</Enum>
+			</EnumInfo>
+			<EnumInfo>
+				<Text>
+					<![CDATA[TCEVENTSEVERITY_Critical]]>
+				</Text>
+				<Enum>4</Enum>
+			</EnumInfo>
+			<Properties>
+				<Property>
+					<Name>plcAttribute_qualified_only</Name>
+				</Property>
+				<Property>
+					<Name>plcAttribute_strict</Name>
+				</Property>
+			</Properties>
+			<Hides>
+				<Hide GUID="{777FF09F-0B00-4AF2-BD7C-C1E2CE4A0947}"/>
+				<Hide GUID="{EC3C119D-4FEC-4197-96FB-DAE1B7C403FB}"/>
+			</Hides>
+		</DataType>
+		<DataType>
+			<Name GUID="{32DBDCFB-9DE9-4726-B195-4528904D5F40}" PersistentType="true">ST_LoggingEventInfo</Name>
+			<BitSize>86272</BitSize>
+			<SubItem>
+				<Name>schema</Name>
+				<Type GUID="{18071995-0000-0000-0000-000100000050}">STRING(80)</Type>
+				<Comment>
+					<![CDATA[Message or Alarm{Cleared,Confirmed,Raised} event information
 
         Note that elements here do not follow the usual Hungarian notation / 
         variable-type-prefixing naming convention due to the member names being
         used directly in the generation of the JSON document.]]>
-                </Comment>
-                <BitSize>648</BitSize>
-                <BitOffs>0</BitOffs>
-                <Default>
-                    <String>
-                        <![CDATA[twincat-event-0]]>
-                    </String>
-                </Default>
-                <Properties>
-                    <Property>
-                        <Name>plcAttribute_pytmc</Name>
-                        <Value>pv: Schema
+				</Comment>
+				<BitSize>648</BitSize>
+				<BitOffs>0</BitOffs>
+				<Default>
+					<String>
+						<![CDATA[twincat-event-0]]>
+					</String>
+				</Default>
+				<Properties>
+					<Property>
+						<Name>plcAttribute_pytmc</Name>
+						<Value>pv: Schema
         io: i
         field: DESC Schema string</Value>
-                    </Property>
-                </Properties>
-            </SubItem>
-            <SubItem>
-                <Name>ts</Name>
-                <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
-                <BitSize>64</BitSize>
-                <BitOffs>704</BitOffs>
-                <Properties>
-                    <Property>
-                        <Name>plcAttribute_pytmc</Name>
-                        <Value>pv: Timestamp 
+					</Property>
+				</Properties>
+			</SubItem>
+			<SubItem>
+				<Name>ts</Name>
+				<Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+				<BitSize>64</BitSize>
+				<BitOffs>704</BitOffs>
+				<Properties>
+					<Property>
+						<Name>plcAttribute_pytmc</Name>
+						<Value>pv: Timestamp 
         io: i
         field: DESC Unix timestamp</Value>
-                    </Property>
-                </Properties>
-            </SubItem>
-            <SubItem>
-                <Name>plc</Name>
-                <Type GUID="{18071995-0000-0000-0000-000100000050}">STRING(80)</Type>
-                <BitSize>648</BitSize>
-                <BitOffs>768</BitOffs>
-                <Properties>
-                    <Property>
-                        <Name>plcAttribute_pytmc</Name>
-                        <Value>pv: Hostname 
+					</Property>
+				</Properties>
+			</SubItem>
+			<SubItem>
+				<Name>plc</Name>
+				<Type GUID="{18071995-0000-0000-0000-000100000050}">STRING(80)</Type>
+				<BitSize>648</BitSize>
+				<BitOffs>768</BitOffs>
+				<Properties>
+					<Property>
+						<Name>plcAttribute_pytmc</Name>
+						<Value>pv: Hostname 
         io: i
         field: DESC PLC Hostname</Value>
-                    </Property>
-                </Properties>
-            </SubItem>
-            <SubItem>
-                <Name>severity</Name>
-                <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
-                <BitSize>16</BitSize>
-                <BitOffs>1424</BitOffs>
-                <Properties>
-                    <Property>
-                        <Name>plcAttribute_pytmc</Name>
-                        <Value>pv: Severity
+					</Property>
+				</Properties>
+			</SubItem>
+			<SubItem>
+				<Name>severity</Name>
+				<Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
+				<BitSize>16</BitSize>
+				<BitOffs>1424</BitOffs>
+				<Properties>
+					<Property>
+						<Name>plcAttribute_pytmc</Name>
+						<Value>pv: Severity
         io: i
         field: DESC TcEventSeverity	
         field: ZRST Verbose
         field: ONST Info
         field: TWST Warning
         field: THST Error</Value>
-                    </Property>
-                </Properties>
-            </SubItem>
-            <SubItem>
-                <Name>id</Name>
-                <Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-                <BitSize>32</BitSize>
-                <BitOffs>1440</BitOffs>
-                <Properties>
-                    <Property>
-                        <Name>plcAttribute_pytmc</Name>
-                        <Value>pv: MessageID
+					</Property>
+				</Properties>
+			</SubItem>
+			<SubItem>
+				<Name>id</Name>
+				<Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
+				<BitSize>32</BitSize>
+				<BitOffs>1440</BitOffs>
+				<Properties>
+					<Property>
+						<Name>plcAttribute_pytmc</Name>
+						<Value>pv: MessageID
         io: i
         field: DESC TwinCAT Message ID</Value>
-                    </Property>
-                </Properties>
-            </SubItem>
-            <SubItem>
-                <Name>event_class</Name>
-                <Type GUID="{18071995-0000-0000-0000-000100000050}">STRING(80)</Type>
-                <BitSize>648</BitSize>
-                <BitOffs>1472</BitOffs>
-                <Properties>
-                    <Property>
-                        <Name>plcAttribute_pytmc</Name>
-                        <Value>pv: EventClass
+					</Property>
+				</Properties>
+			</SubItem>
+			<SubItem>
+				<Name>event_class</Name>
+				<Type GUID="{18071995-0000-0000-0000-000100000050}">STRING(80)</Type>
+				<BitSize>648</BitSize>
+				<BitOffs>1472</BitOffs>
+				<Properties>
+					<Property>
+						<Name>plcAttribute_pytmc</Name>
+						<Value>pv: EventClass
         io: i
         field: DESC TwinCAT Event class</Value>
-                    </Property>
-                </Properties>
-            </SubItem>
-            <SubItem>
-                <Name>msg</Name>
-                <Type GUID="{18071995-0000-0000-0000-0001000000FF}">STRING(255)</Type>
-                <BitSize>2048</BitSize>
-                <BitOffs>2120</BitOffs>
-                <Properties>
-                    <Property>
-                        <Name>plcAttribute_pytmc</Name>
-                        <Value>pv: Message
+					</Property>
+				</Properties>
+			</SubItem>
+			<SubItem>
+				<Name>msg</Name>
+				<Type GUID="{18071995-0000-0000-0000-0001000000FF}">STRING(255)</Type>
+				<BitSize>2048</BitSize>
+				<BitOffs>2120</BitOffs>
+				<Properties>
+					<Property>
+						<Name>plcAttribute_pytmc</Name>
+						<Value>pv: Message
         io: i</Value>
-                    </Property>
-                </Properties>
-            </SubItem>
-            <SubItem>
-                <Name>source</Name>
-                <Type GUID="{18071995-0000-0000-0000-0001000000FF}">STRING(255)</Type>
-                <Comment>
-                    <![CDATA[This is actually: T_MaxString
+					</Property>
+				</Properties>
+			</SubItem>
+			<SubItem>
+				<Name>source</Name>
+				<Type GUID="{18071995-0000-0000-0000-0001000000FF}">STRING(255)</Type>
+				<Comment>
+					<![CDATA[This is actually: T_MaxString
  which has been expanded due to requirements for pinning global data types.]]>
-                </Comment>
-                <BitSize>2048</BitSize>
-                <BitOffs>4168</BitOffs>
-                <Properties>
-                    <Property>
-                        <Name>plcAttribute_pytmc</Name>
-                        <Value>pv: Source
+				</Comment>
+				<BitSize>2048</BitSize>
+				<BitOffs>4168</BitOffs>
+				<Properties>
+					<Property>
+						<Name>plcAttribute_pytmc</Name>
+						<Value>pv: Source
         io: i</Value>
-                    </Property>
-                </Properties>
-            </SubItem>
-            <SubItem>
-                <Name>event_type</Name>
-                <Type GUID="{A81A482A-E7CE-49D8-A4DD-8280773A6946}">E_LogEventType</Type>
-                <Comment>
-                    <![CDATA[This is actually: STRING(Tc3_EventLogger.ParameterList.cSourceNameSize - 1)
+					</Property>
+				</Properties>
+			</SubItem>
+			<SubItem>
+				<Name>event_type</Name>
+				<Type GUID="{A81A482A-E7CE-49D8-A4DD-8280773A6946}">E_LogEventType</Type>
+				<Comment>
+					<![CDATA[This is actually: STRING(Tc3_EventLogger.ParameterList.cSourceNameSize - 1)
  which has been expanded due to requirements for pinning global data types.]]>
-                </Comment>
-                <BitSize>16</BitSize>
-                <BitOffs>6224</BitOffs>
-                <Properties>
-                    <Property>
-                        <Name>plcAttribute_pytmc</Name>
-                        <Value>pv: EventType
+				</Comment>
+				<BitSize>16</BitSize>
+				<BitOffs>6224</BitOffs>
+				<Properties>
+					<Property>
+						<Name>plcAttribute_pytmc</Name>
+						<Value>pv: EventType
         io: i
         field: DESC The event type</Value>
-                    </Property>
-                </Properties>
-            </SubItem>
-            <SubItem>
-                <Name>json</Name>
-                <Type GUID="{18071995-0000-0000-0000-000100002710}">STRING(10000)</Type>
-                <BitSize>80008</BitSize>
-                <BitOffs>6240</BitOffs>
-                <Properties>
-                    <Property>
-                        <Name>plcAttribute_pytmc</Name>
-                        <Value>pv: MessageJSON
+					</Property>
+				</Properties>
+			</SubItem>
+			<SubItem>
+				<Name>json</Name>
+				<Type GUID="{18071995-0000-0000-0000-000100002710}">STRING(10000)</Type>
+				<BitSize>80008</BitSize>
+				<BitOffs>6240</BitOffs>
+				<Properties>
+					<Property>
+						<Name>plcAttribute_pytmc</Name>
+						<Value>pv: MessageJSON
         io: i
         field: DESC Metadata with the message</Value>
-                    </Property>
-                </Properties>
-            </SubItem>
-            <Hides>
-                <Hide GUID="{91686BB0-81A3-47A0-8E20-449823CCE7F0}"/>
-            </Hides>
-        </DataType>
-        <DataType>
-            <Name GUID="{85DC3E7A-8ADA-435B-9479-25573909A7DB}" Namespace="AX5000" TcBaseType="true">E_AX5000_P_0275_ActiveFeedbackAndMemory</Name>
-            <BitSize>8</BitSize>
-            <BaseType GUID="{18071995-0000-0000-0000-000000000001}">BYTE</BaseType>
-            <EnumInfo>
-                <Text>
-                    <![CDATA[EAX5000_P_0275_MEMORY_NONE]]>
-                </Text>
-                <Enum>0</Enum>
-            </EnumInfo>
-            <EnumInfo>
-                <Text>
-                    <![CDATA[EAX5000_P_0275_FEEDBACK1_MEMORY_ENCODER]]>
-                </Text>
-                <Enum>1</Enum>
-            </EnumInfo>
-            <EnumInfo>
-                <Text>
-                    <![CDATA[EAX5000_P_0275_FEEDBACK1_MEMORY_DRIVE]]>
-                </Text>
-                <Enum>2</Enum>
-            </EnumInfo>
-            <EnumInfo>
-                <Text>
-                    <![CDATA[EAX5000_P_0275_FEEDBACK2_MEMORY_ENCODER]]>
-                </Text>
-                <Enum>8</Enum>
-            </EnumInfo>
-            <EnumInfo>
-                <Text>
-                    <![CDATA[EAX5000_P_0275_FEEDBACK2_MEMORY_DRIVE]]>
-                </Text>
-                <Enum>16</Enum>
-            </EnumInfo>
-            <Hides>
-                <Hide GUID="{F1A82E04-2D76-4E5D-BB15-437337214D25}"/>
-            </Hides>
-        </DataType>
-        <DataType>
-            <Name GUID="{D7D16A25-71D5-48E0-882D-56AB4D826BC2}" Namespace="AX5000" PersistentType="true">ST_AX5000_P_0275</Name>
-            <BitSize>16</BitSize>
-            <SubItem>
-                <Name>ActiveFeedbackAndMemory</Name>
-                <Type GUID="{85DC3E7A-8ADA-435B-9479-25573909A7DB}" Namespace="AX5000">E_AX5000_P_0275_ActiveFeedbackAndMemory</Type>
-                <BitSize>8</BitSize>
-                <BitOffs>0</BitOffs>
-            </SubItem>
-            <SubItem>
-                <Name>InitializationErrorBehavior</Name>
-                <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
-                <BitSize>1</BitSize>
-                <BitOffs>8</BitOffs>
-            </SubItem>
-            <Hides>
-                <Hide GUID="{0D1A14D3-018F-4F48-88A7-90B490A317B5}"/>
-                <Hide GUID="{43B3CFF1-FA94-4CC1-8B03-C73EF940373B}"/>
-                <Hide GUID="{81B09CD0-943C-4070-AA5B-0A6818251CEB}"/>
-                <Hide GUID="{B6598B95-DC2C-454C-9B12-DE628B32D897}"/>
-            </Hides>
-        </DataType>
-    </DataTypes>
-    <Project ProjectGUID="{9AC02CD1-4FA4-49DE-BC09-848126C612E3}" TargetNetId="172.21.148.145.1.1" ShowHideConfigurations="#x6">
-        <System>
-            <Licenses>
-                <Target>
-                    <ManualSelect>{3EBB9639-5FF3-42B6-8847-35C70DC013C8}</ManualSelect>
-                </Target>
-            </Licenses>
-            <Tasks>
-                <Task Id="3" Priority="1" CycleTime="100000" AmsPort="350" AdtTasks="true">
-                    <Name>Task 3</Name>
-                </Task>
-            </Tasks>
-        </System>
-        <Plc>
-            <Project GUID="{DF4CAFE9-8807-49B7-953A-22D467A15EF7}" Name="LCLSGeneral" PrjFilePath="LCLSGeneral\LCLSGeneral.plcproj" TmcFilePath="LCLSGeneral\LCLSGeneral.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e">
-                <Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="LCLSGeneral\LCLSGeneral.tmc">
-                    <Name>LCLSGeneral Instance</Name>
-                    <CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
-                    <Vars VarGrpType="1">
-                        <Name>Task_3 Inputs</Name>
-                        <Var>
-                            <Name>DefaultGlobals.stSys.I_EcatMaster1</Name>
-                            <Comment>
-                                <![CDATA[ AMS Net ID used for FB_EcatDiag, among others ]]>
-                            </Comment>
-                            <Type GUID="{18071995-0000-0000-0000-000000000041}">AMSNETID</Type>
-                        </Var>
-                    </Vars>
-                    <TaskPouOids>
-                        <TaskPouOid Prio="1" OTCID="#x08502001"/>
-                    </TaskPouOids>
-                </Instance>
-            </Project>
-        </Plc>
-    </Project>
+					</Property>
+				</Properties>
+			</SubItem>
+			<Hides>
+				<Hide GUID="{91686BB0-81A3-47A0-8E20-449823CCE7F0}"/>
+			</Hides>
+		</DataType>
+		<DataType>
+			<Name GUID="{85DC3E7A-8ADA-435B-9479-25573909A7DB}" Namespace="AX5000" TcBaseType="true">E_AX5000_P_0275_ActiveFeedbackAndMemory</Name>
+			<BitSize>8</BitSize>
+			<BaseType GUID="{18071995-0000-0000-0000-000000000001}">BYTE</BaseType>
+			<EnumInfo>
+				<Text>
+					<![CDATA[EAX5000_P_0275_MEMORY_NONE]]>
+				</Text>
+				<Enum>0</Enum>
+			</EnumInfo>
+			<EnumInfo>
+				<Text>
+					<![CDATA[EAX5000_P_0275_FEEDBACK1_MEMORY_ENCODER]]>
+				</Text>
+				<Enum>1</Enum>
+			</EnumInfo>
+			<EnumInfo>
+				<Text>
+					<![CDATA[EAX5000_P_0275_FEEDBACK1_MEMORY_DRIVE]]>
+				</Text>
+				<Enum>2</Enum>
+			</EnumInfo>
+			<EnumInfo>
+				<Text>
+					<![CDATA[EAX5000_P_0275_FEEDBACK2_MEMORY_ENCODER]]>
+				</Text>
+				<Enum>8</Enum>
+			</EnumInfo>
+			<EnumInfo>
+				<Text>
+					<![CDATA[EAX5000_P_0275_FEEDBACK2_MEMORY_DRIVE]]>
+				</Text>
+				<Enum>16</Enum>
+			</EnumInfo>
+			<Hides>
+				<Hide GUID="{F1A82E04-2D76-4E5D-BB15-437337214D25}"/>
+			</Hides>
+		</DataType>
+		<DataType>
+			<Name GUID="{D7D16A25-71D5-48E0-882D-56AB4D826BC2}" Namespace="AX5000" PersistentType="true">ST_AX5000_P_0275</Name>
+			<BitSize>16</BitSize>
+			<SubItem>
+				<Name>ActiveFeedbackAndMemory</Name>
+				<Type GUID="{85DC3E7A-8ADA-435B-9479-25573909A7DB}" Namespace="AX5000">E_AX5000_P_0275_ActiveFeedbackAndMemory</Type>
+				<BitSize>8</BitSize>
+				<BitOffs>0</BitOffs>
+			</SubItem>
+			<SubItem>
+				<Name>InitializationErrorBehavior</Name>
+				<Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+				<BitSize>1</BitSize>
+				<BitOffs>8</BitOffs>
+			</SubItem>
+			<Hides>
+				<Hide GUID="{0D1A14D3-018F-4F48-88A7-90B490A317B5}"/>
+				<Hide GUID="{43B3CFF1-FA94-4CC1-8B03-C73EF940373B}"/>
+				<Hide GUID="{81B09CD0-943C-4070-AA5B-0A6818251CEB}"/>
+				<Hide GUID="{B6598B95-DC2C-454C-9B12-DE628B32D897}"/>
+			</Hides>
+		</DataType>
+	</DataTypes>
+	<Project ProjectGUID="{9AC02CD1-4FA4-49DE-BC09-848126C612E3}" TargetNetId="172.21.148.145.1.1" ShowHideConfigurations="#x6">
+		<System>
+			<Licenses>
+				<Target>
+					<ManualSelect>{3EBB9639-5FF3-42B6-8847-35C70DC013C8}</ManualSelect>
+				</Target>
+			</Licenses>
+			<Tasks>
+				<Task Id="3" Priority="1" CycleTime="100000" AmsPort="350" AdtTasks="true">
+					<Name>Task 3</Name>
+				</Task>
+			</Tasks>
+		</System>
+		<Plc>
+			<Project GUID="{DF4CAFE9-8807-49B7-953A-22D467A15EF7}" Name="LCLSGeneral" PrjFilePath="LCLSGeneral\LCLSGeneral.plcproj" TmcFilePath="LCLSGeneral\LCLSGeneral.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e">
+				<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="LCLSGeneral\LCLSGeneral.tmc">
+					<Name>LCLSGeneral Instance</Name>
+					<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
+					<Vars VarGrpType="1">
+						<Name>Task_3 Inputs</Name>
+						<Var>
+							<Name>DefaultGlobals.stSys.I_EcatMaster1</Name>
+							<Comment>
+								<![CDATA[ AMS Net ID used for FB_EcatDiag, among others ]]>
+							</Comment>
+							<Type GUID="{18071995-0000-0000-0000-000000000041}">AMSNETID</Type>
+						</Var>
+					</Vars>
+					<TaskPouOids>
+						<TaskPouOid Prio="1" OTCID="#x08502001"/>
+					</TaskPouOids>
+				</Instance>
+			</Project>
+		</Plc>
+	</Project>
 </TcSmProject>

--- a/LCLSGeneral/LCLSGeneral/Data types/EPICS/ST_EpicsMotorMSTA.TcDUT
+++ b/LCLSGeneral/LCLSGeneral/Data types/EPICS/ST_EpicsMotorMSTA.TcDUT
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+  <DUT Name="ST_EpicsMotorMSTA" Id="{8dc1ba89-a69d-4583-94a8-23394c1f2a52}">
+    <Declaration><![CDATA[TYPE ST_EpicsMotorMSTA :
+STRUCT
+
+    (* DIRECTION: last raw direction; (0:Negative, 1:Positive) *)
+    bPositiveDirection : BIT;
+    (* DONE: motion is complete. *)
+    bDone : BIT;
+    (* PLUS_LS: plus limit switch has been hit. *)
+    bPlusLimitSwitch : BIT;
+    (* HOMELS: state of the home limit switch. *)
+    bHomeLimitSwitch : BIT;
+    (* Unused *)
+    bUnused0 : BIT;
+    (* POSITION: closed-loop position control is enabled. *)
+    bClosedLoop : BIT;
+    (* SLIP_STALL: Slip/Stall detected (eg. fatal following error) *)
+    bSlipStall : BIT;
+    (* HOME: if at home position. *)
+    bHome : BIT;
+    (* PRESENT: encoder is present. *)
+    bEncoderPresent : BIT;
+    (* PROBLEM: driver stopped polling, or hardware problem *)
+    bHardwareProblem : BIT;
+    (* MOVING: non-zero velocity present. *)
+    bMoving : BIT;
+    (* GAIN_SUPPORT: motor supports closed-loop position control. *)
+    bGainSupport : BIT;
+    (* COMM_ERR: Controller communication error. *)
+    bCommError : BIT;
+    (* MINUS_LS: minus limit switch has been hit. *)
+    bMinusLimitSwitch : BIT;
+    (* HOMED: the motor has been homed. *)
+    bHomed : BIT;
+
+END_STRUCT
+END_TYPE
+]]></Declaration>
+  </DUT>
+</TcPlcObject>

--- a/LCLSGeneral/LCLSGeneral/LCLSGeneral.plcproj
+++ b/LCLSGeneral/LCLSGeneral/LCLSGeneral.plcproj
@@ -94,6 +94,9 @@
     <Compile Include="POUs\Data\Tests\FB_Test_EpicsCentroidMonitor.TcPOU">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="POUs\Data\Tests\FB_Test_EpicsMotorMonitor.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="POUs\Diagnostics\DUT\E_EcatDiagState.TcDUT">
       <SubType>Code</SubType>
     </Compile>

--- a/LCLSGeneral/LCLSGeneral/LCLSGeneral.plcproj
+++ b/LCLSGeneral/LCLSGeneral/LCLSGeneral.plcproj
@@ -31,6 +31,7 @@
   <ItemGroup>
     <Folder Include="Data types" />
     <Folder Include="Data types\Misc" />
+    <Folder Include="Data types\EPICS" />
     <Folder Include="GVLs" />
     <Folder Include="POUs" />
     <Folder Include="POUs\Diagnostics\DUT" />
@@ -43,6 +44,9 @@
     <Folder Include="POUs\Logger\Tests" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Data types\EPICS\ST_EpicsMotorMSTA.TcDUT">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="Data types\Misc\ST_EcDevice.TcDUT">
       <SubType>Code</SubType>
     </Compile>
@@ -63,6 +67,12 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="POUs\Data\FB_DataBuffer.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="POUs\Data\FB_EpicsCentroidMonitor.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="POUs\Data\FB_EpicsMotorMonitor.TcPOU">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="POUs\Data\FB_LREALBuffer.TcPOU">

--- a/LCLSGeneral/LCLSGeneral/LCLSGeneral.plcproj
+++ b/LCLSGeneral/LCLSGeneral/LCLSGeneral.plcproj
@@ -34,6 +34,7 @@
     <Folder Include="Data types\EPICS" />
     <Folder Include="GVLs" />
     <Folder Include="POUs" />
+    <Folder Include="POUs\Data\Tests" />
     <Folder Include="POUs\Diagnostics\DUT" />
     <Folder Include="POUs\Functions" />
     <Folder Include="POUs\Logger" />
@@ -88,6 +89,9 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="POUs\Data\FB_TimeStampBufferGlobal.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="POUs\Data\Tests\FB_Test_EpicsCentroidMonitor.TcPOU">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="POUs\Diagnostics\DUT\E_EcatDiagState.TcDUT">

--- a/LCLSGeneral/LCLSGeneral/POUs/Data/FB_EpicsCentroidMonitor.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Data/FB_EpicsCentroidMonitor.TcPOU
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+  <POU Name="FB_EpicsCentroidMonitor" Id="{b49e72a7-c7c2-451d-96d1-aade68e9ce98}" SpecialFunc="None">
+    <Declaration><![CDATA[(*
+    EPICS AreaDetector Stats Plugin Centroid Monitor
+
+    Requires a "link" pragma to specify the full plugin prefix.
+
+*)
+FUNCTION_BLOCK FB_EpicsCentroidMonitor
+VAR_INPUT
+    fMaximumFrameTime : LREAL := 0.2;
+    fMinimumChange : LREAL := 0.05;
+    bEnable : BOOL := TRUE;
+END_VAR
+VAR_OUTPUT
+    {attribute 'pytmc' := '
+        pv: IsUpdating
+        io: input
+    '}
+    bIsUpdating : BOOL;
+    {attribute 'pytmc' := '
+        pv: CentroidX
+        io: input
+    '}
+    fCentroidX : LREAL;
+    {attribute 'pytmc' := '
+        pv: CentroidY
+        io: input
+    '}
+    fCentroidY : LREAL;
+    {attribute 'pytmc' := '
+        pv: ArrayCount
+        io: input
+    '}
+    nArrayCount : UDINT;
+    bValid : BOOL;
+    {attribute 'pytmc' := '
+        pv: FrameTime
+        io: input
+        field: DESC Time between frame updates
+        field: EGU sec
+    '}
+    fFrameTime : LREAL;
+END_VAR
+VAR
+    {attribute 'pytmc' := '
+        pv: CX_
+        link: CentroidX_RBV
+    '}
+    fbCentroidX : FB_LREALFromEPICS;
+
+    {attribute 'pytmc' := '
+        pv: CY_
+        link: CentroidY_RBV
+    '}
+    fbCentroidY : FB_LREALFromEPICS;
+
+    fLastCentroidX : LREAL;
+    fLastCentroidY : LREAL;
+
+    {attribute 'pytmc' := '
+        pv: Cnt_
+        link: ArrayCounter_RBV
+    '}
+    fbArrayCounter : FB_LREALFromEPICS;
+
+    // Last array count value
+    nLastArrayCount : UDINT;
+    // Time of the last frame update
+    tLastUpdate: TIME;
+
+    bInit : BOOL;
+    // Did we see a frame update yet?
+    bSawFrame : BOOL;
+    bHaveNewFrame : BOOL;
+
+END_VAR]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[IF NOT bEnable THEN
+    bValid := FALSE;
+    RETURN;
+END_IF
+
+IF NOT bInit THEN
+    tLastUpdate := TIME();
+    fFrameTime := 1000.0;
+    bSawFrame := FALSE;
+    bInit := TRUE;
+END_IF
+
+fbCentroidX();
+fbCentroidY();
+fbArrayCounter();
+
+bValid := (
+    fbCentroidX.bValid AND
+    fbCentroidY.bValid AND
+    fbArrayCounter.bValid
+);
+
+fCentroidX := fbCentroidX.fValue;
+fCentroidY := fbCentroidY.fValue;
+nArrayCount := LREAL_TO_UDINT(fbArrayCounter.fValue);
+
+bHaveNewFrame := (
+    nArrayCount <> nLastArrayCount AND
+    ABS(fLastCentroidX - fCentroidX) >= GVL_BTPS_Retain.fMinCentroidChange AND
+    ABS(fLastCentroidY - fCentroidY) >= GVL_BTPS_Retain.fMinCentroidChange AND
+    TRUE
+);
+
+IF bHaveNewFrame THEN
+    fFrameTime := TIME_TO_LREAL(TIME() - tLastUpdate) * 0.001; // Milliseconds -> seconds
+    tLastUpdate := TIME();
+    nLastArrayCount := nArrayCount;
+    bSawFrame := TRUE;
+
+    fLastCentroidX := fCentroidX;
+    fLastCentroidY := fCentroidY;
+END_IF
+
+bIsUpdating := bSawFrame AND (fFrameTime <= GVL_BTPS_Retain.fMaximumFrameTime);]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/LCLSGeneral/LCLSGeneral/POUs/Data/FB_EpicsCentroidMonitor.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Data/FB_EpicsCentroidMonitor.TcPOU
@@ -4,7 +4,85 @@
     <Declaration><![CDATA[(*
     EPICS AreaDetector Stats Plugin Centroid Monitor
 
-    Requires a "link" pragma to specify the full plugin prefix.
+    Requirements:
+
+    * Requires an existing IOC with an EPICS AreaDetector.
+    * Requires an AreaDetector plugin chain that includes a stats plugin.
+    * Requires a pytmc "link" pragma to specify the plugin PV prefix.
+
+    What information is included?
+
+    * Centroid X position
+    * Centroid Y position
+    * Array count index
+    * The validity of the data, as determined by:
+        - The ArrayCounter_RBV PV changing
+        - Alarm severity of the PVs
+        - The centroid value changing, even minimally
+
+    Example:
+
+        {attribute 'pytmc' := '
+            pv: @(PREFIX):Chk:Centroid1
+            link: AREA:DETECTOR:CAM:01:Stats2:
+        '}
+        fbCentroid : FB_EpicsCentroidMonitor;
+
+        fbCentroid(bEnable:=TRUE, fMinimumValidChange:=1E-6, fNewFrameMinimumChange:=1E-6);
+        IF fbCentroid.bValid AND fbCentroid.bIsUpdating THEN
+            fbCentroid.fCentroidX;
+            fbCentroid.fCentroidY;
+            fbCentroid.nArrayCount;
+            fbCentroid.fFrameTime;
+        END_IF
+
+    Above, ``AREA:DETECTOR:CAM:01:Stats2`` should refer to the PV prefix of a
+    stats plugin.
+    That is, ``caget AREA:DETECTOR:CAM:01:Stats2:ArrayCounter_RBV`` should not
+    fail.
+
+    How does this work?
+
+    pytmc offers the ability to push EPICS process variable data into PLCs by
+    way of link pragmas.  These link pragmas create additional supporting EPICS
+    records that monitor PVs from any IOC on the controls network. In this case,
+    the PLC IOC will monitor vital AreaDetector plugin record data and let your
+    PLC project know of its status.
+
+    Why are there multiple thresholds I have to specify?
+
+    ``fNewFrameMinimumChange`` is the minimum change in pixels to say that
+    when the array counter changes, these are the new values for X and Y.
+    While this seems a bit confusing (or perhaps unnecessary), we do not
+    know when the array counters or centroid values will be updated.  These
+    do not get written in a single, atomic write to the PLC. We may see an
+    updated array count and then a centroid X change and then a Y change.
+    This threshold is a way of working around that complexity and saying
+    the new data is here only when it's changed at least a bit and we have
+    a new frame number.
+
+    ``fMinimumValidChange``, which by default is set to the same as the above
+    threshold, says that if the centroid value doesn't change by at least this
+    on a frame-to-frame basis, consider this a result of a faulty AreaDetector
+    implementation.  The monitor would report values below this threshold as
+    "not updating" - ``bIsUpdating`` as ``FALSE``.
+
+    What needs to happen to get new centroid values?
+
+    - An updated array count
+    - An updated X centroid value (above fNewFrameMinimumChange)
+    - An updated Y centroid value (above fNewFrameMinimumChange)
+    - NO_ALARM severities for all values
+
+    This will result in an updated:
+
+    - fFrameTime (seconds between valid frames)
+
+    What needs to happen for ``bIsUpdating`` to be TRUE?
+
+    - All items from the above "new centroid values"
+    - Frame time below fMaximumFrameTime
+    - Centroid X and Y values above fMinimumValidChange
 
 *)
 FUNCTION_BLOCK FB_EpicsCentroidMonitor

--- a/LCLSGeneral/LCLSGeneral/POUs/Data/FB_EpicsCentroidMonitor.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Data/FB_EpicsCentroidMonitor.TcPOU
@@ -10,7 +10,10 @@
 FUNCTION_BLOCK FB_EpicsCentroidMonitor
 VAR_INPUT
     fMaximumFrameTime : LREAL := 0.2;
-    fMinimumChange : LREAL := 0.05;
+    (* Minimum change to be considered updating correctly - buggy detectors may need this. *)
+    fMinimumValidChange : LREAL := 1E-6;
+    (* Minimum change in pixels to be considered a new value for X, Y *)
+    fNewFrameMinimumChange : LREAL := 1E-6;
     bEnable : BOOL := TRUE;
 END_VAR
 VAR_OUTPUT
@@ -71,9 +74,12 @@ VAR
     tLastUpdate: TIME;
 
     bInit : BOOL;
-    // Did we see a frame update yet?
+    // Did we see a frame update yet? (FALSE at startup; TRUE after first frame.)
     bSawFrame : BOOL;
+    // Do we have a new frame? Has the array count updated, and position change above fNewFrameMinimumChange?
     bHaveNewFrame : BOOL;
+    // For this new frame, is it above the threshold fMinimumValidChange?
+    bAboveThreshold : BOOL;
 
 END_VAR]]></Declaration>
     <Implementation>
@@ -103,14 +109,27 @@ fCentroidX := fbCentroidX.fValue;
 fCentroidY := fbCentroidY.fValue;
 nArrayCount := LREAL_TO_UDINT(fbArrayCounter.fValue);
 
+(*
+    Only consider that we have a new frame if:
+    1. The array count has been updated
+    2. X and Y values have changed even minimally
+        a. With background noise, this should not be a problem.
+        b. With an invalid black/white/stale image, this will indicate
+           'no new frame' despite an increasing array count.
+*)
 bHaveNewFrame := (
     nArrayCount <> nLastArrayCount AND
-    ABS(fLastCentroidX - fCentroidX) >= GVL_BTPS_Retain.fMinCentroidChange AND
-    ABS(fLastCentroidY - fCentroidY) >= GVL_BTPS_Retain.fMinCentroidChange AND
+    ABS(fLastCentroidX - fCentroidX) >= fNewFrameMinimumChange AND
+    ABS(fLastCentroidY - fCentroidY) >= fNewFrameMinimumChange AND
     TRUE
 );
 
 IF bHaveNewFrame THEN
+    bAboveThreshold := (
+        ABS(fLastCentroidX - fCentroidX) >= fMinimumValidChange AND
+        ABS(fLastCentroidY - fCentroidY) >= fMinimumValidChange
+    );
+
     fFrameTime := TIME_TO_LREAL(TIME() - tLastUpdate) * 0.001; // Milliseconds -> seconds
     tLastUpdate := TIME();
     nLastArrayCount := nArrayCount;
@@ -120,7 +139,7 @@ IF bHaveNewFrame THEN
     fLastCentroidY := fCentroidY;
 END_IF
 
-bIsUpdating := bSawFrame AND (fFrameTime <= GVL_BTPS_Retain.fMaximumFrameTime);]]></ST>
+bIsUpdating := bSawFrame AND (fFrameTime <= fMaximumFrameTime) AND bAboveThreshold;]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/LCLSGeneral/LCLSGeneral/POUs/Data/FB_EpicsMotorMonitor.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Data/FB_EpicsMotorMonitor.TcPOU
@@ -1,0 +1,75 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+  <POU Name="FB_EpicsMotorMonitor" Id="{c6bf2af8-e9b0-4ebb-b06e-d35a94600f72}" SpecialFunc="None">
+    <Declaration><![CDATA[(*
+    EPICS Motor Record Monitoring tool
+
+    Requires a "link" pragma to specify the motor record prefix.
+
+*)
+FUNCTION_BLOCK FB_EpicsMotorMonitor
+VAR_INPUT
+    bEnable : BOOL := TRUE;
+END_VAR
+VAR_OUTPUT
+    bIsMoving : BOOL;
+    fPosition : LREAL;
+    nMSTA_Raw : UINT;
+    stMSTA : ST_EpicsMotorMSTA;
+    bValid : BOOL;
+END_VAR
+VAR
+    {attribute 'pytmc' := '
+        pv: RBV_
+        link: .RBV
+    '}
+    fbRBVCheck : FB_LREALFromEPICS;
+
+    {attribute 'pytmc' := '
+        pv: Dmov_
+        link: .DMOV
+    '}
+    fbMovingCheck : FB_LREALFromEPICS;
+
+    {attribute 'pytmc' := '
+        pv: Msta_
+        link: .MSTA
+    '}
+    fbMotorStatusCheck : FB_LREALFromEPICS;
+END_VAR]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[IF NOT bEnable THEN
+    bValid := FALSE;
+    RETURN;
+END_IF
+
+fbRBVCheck();
+fbMovingCheck();
+fbMotorStatusCheck();
+bValid := (
+    fbRBVCheck.bValid AND
+    fbMovingCheck.bValid AND
+    fbMotorStatusCheck.bValid
+);
+bIsMoving := ABS(fbMovingCheck.fValue) < 1e-5;
+fPosition := fbRBVCheck.fValue;
+
+nMSTA_Raw := LREAL_TO_UINT(fbMotorStatusCheck.fValue);
+stMSTA.bPositiveDirection := nMSTA_Raw.0;
+stMSTA.bDone := nMSTA_Raw.1;
+stMSTA.bPlusLimitSwitch := nMSTA_Raw.2;
+stMSTA.bHomeLimitSwitch := nMSTA_Raw.3;
+stMSTA.bUnused0 := nMSTA_Raw.4;
+stMSTA.bClosedLoop := nMSTA_Raw.5;
+stMSTA.bSlipStall := nMSTA_Raw.6;
+stMSTA.bHome := nMSTA_Raw.7;
+stMSTA.bEncoderPresent := nMSTA_Raw.8;
+stMSTA.bHardwareProblem := nMSTA_Raw.9;
+stMSTA.bMoving := nMSTA_Raw.10;
+stMSTA.bGainSupport := nMSTA_Raw.11;
+stMSTA.bCommError := nMSTA_Raw.12;
+stMSTA.bMinusLimitSwitch := nMSTA_Raw.13;
+stMSTA.bHomed := nMSTA_Raw.14;]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/LCLSGeneral/LCLSGeneral/POUs/Data/FB_EpicsMotorMonitor.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Data/FB_EpicsMotorMonitor.TcPOU
@@ -51,6 +51,11 @@ bValid := (
     fbMovingCheck.bValid AND
     fbMotorStatusCheck.bValid
 );
+
+(* Moving status is DMOV; this comes in as a floating point value
+     DMOV = 0 -> moving
+     DMOV = 1 -> done moving, or not moving
+*)
 bIsMoving := ABS(fbMovingCheck.fValue) < 1e-5;
 fPosition := fbRBVCheck.fValue;
 

--- a/LCLSGeneral/LCLSGeneral/POUs/Data/FB_EpicsMotorMonitor.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Data/FB_EpicsMotorMonitor.TcPOU
@@ -4,7 +4,48 @@
     <Declaration><![CDATA[(*
     EPICS Motor Record Monitoring tool
 
-    Requires a "link" pragma to specify the motor record prefix.
+    Requirements:
+
+    * Requires an existing IOC with an EPICS motor record.
+    * Requires a pytmc "link" pragma to specify the motor record prefix.
+
+    What information is included?
+
+    * The validity of the source data (as determined by alarm severity)
+    * Readback value (scaled encoder position in ``fPosition``)
+    * Motion status (moving or not, ``bIsMoving``)
+    * Homed status, limit status, and others (via ``stMSTA``, see
+      ``ST_EpicsMotorMSTA``).
+
+    Example:
+
+        {attribute 'pytmc' := '
+            pv: @(PREFIX):Internal:Mon
+            link: MOTOR:PV:NAME
+        '}
+        fbMotorMonitor : FB_EpicsMotorMonitor;
+
+        fbMotorMonitor(bEnable:=TRUE);
+        IF fbMotorMonitor.bValid THEN
+            fbMotorMonitor.fPosition;
+            fbMotorMonitor.bIsMoving;
+            fbMotorMonitor.stMSTA.bHomed;
+        END_IF
+    
+    Above, ``MOTOR:PV:NAME`` should refer to an EPICS motor record.
+    That is, ``caget MOTOR:PV:NAME.RTYP`` should return "motor".
+
+    How does this work?
+
+    pytmc offers the ability to push EPICS process variable data into PLCs by
+    way of link pragmas.  These link pragmas create additional supporting EPICS
+    records that monitor PVs from any IOC on the controls network. In this case,
+    the PLC IOC will monitor vital motor record information and let your PLC
+    project know of its status.
+
+    Note that not all motor records may be created equally.  Some of the status
+    fields may not be consistent.  Be sure to check how your motor works and
+    what fields are worth paying attention to when using this.
 
 *)
 FUNCTION_BLOCK FB_EpicsMotorMonitor

--- a/LCLSGeneral/LCLSGeneral/POUs/Data/Tests/FB_Test_EpicsCentroidMonitor.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Data/Tests/FB_Test_EpicsCentroidMonitor.TcPOU
@@ -20,7 +20,6 @@ END_VAR
 VAR_INST
     fbMonitor : FB_EpicsCentroidMonitor;
     nCount : INT := 0;
-    bInit : BOOL := FALSE;
 END_VAR]]></Declaration>
       <Implementation>
         <ST><![CDATA[TEST('Basic');

--- a/LCLSGeneral/LCLSGeneral/POUs/Data/Tests/FB_Test_EpicsCentroidMonitor.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Data/Tests/FB_Test_EpicsCentroidMonitor.TcPOU
@@ -1,0 +1,116 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+  <POU Name="FB_Test_EpicsCentroidMonitor" Id="{f2b9a982-0418-41c7-aafe-94902ffcfe9d}" SpecialFunc="None">
+    <Declaration><![CDATA[{attribute 'call_after_init'}
+FUNCTION_BLOCK FB_Test_EpicsCentroidMonitor EXTENDS TcUnit.FB_TestSuite
+VAR_INPUT
+END_VAR
+VAR_OUTPUT
+END_VAR
+VAR
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[TestBasics();]]></ST>
+    </Implementation>
+    <Method Name="TestBasics" Id="{2953f222-cbed-4db0-9aaa-214604e5b113}">
+      <Declaration><![CDATA[METHOD TestBasics
+VAR_INPUT
+END_VAR
+VAR_INST
+    fbMonitor : FB_EpicsCentroidMonitor;
+    nCount : INT := 0;
+    bInit : BOOL := FALSE;
+END_VAR]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[TEST('Basic');
+
+nCount := 0;
+
+nCount := nCount + 1;
+WriteCentroidValue(fbMonitor:=fbMonitor, fX:=0.0, fY:=0.0, nCount:=nCount, nX_Severity:=0, nY_Severity:=0, nCount_Severity:=0, tLastUpdate:=T#0S);
+fbMonitor();
+
+nCount := nCount + 1;
+WriteCentroidValue(fbMonitor:=fbMonitor, fX:=0.1, fY:=0.1, nCount:=nCount, nX_Severity:=0, nY_Severity:=0, nCount_Severity:=0, tLastUpdate:=T#0S);
+fbMonitor(fMinimumValidChange:=0.0);
+
+AssertTrue(fbMonitor.bIsUpdating, Message:='Centroid not reporting updating');
+
+TEST_FINISHED();
+
+TEST('Min change');
+
+nCount := nCount + 1;
+WriteCentroidValue(fbMonitor:=fbMonitor, fX:=0.0, fY:=0.0, nCount:=nCount, nX_Severity:=0, nY_Severity:=0, nCount_Severity:=0, tLastUpdate:=T#0S);
+fbMonitor(fMinimumValidChange:=0.1, fMaximumFrameTime:=0.2);
+
+nCount := nCount + 1;
+WriteCentroidValue(fbMonitor:=fbMonitor, fX:=0.05, fY:=0.05, nCount:=nCount, nX_Severity:=0, nY_Severity:=0, nCount_Severity:=0, tLastUpdate:=T#0.1S);
+fbMonitor(fMinimumValidChange:=0.1, fMaximumFrameTime:=0.2);
+AssertFalse(fbMonitor.bIsUpdating, Message:='Centroid update below threshold and is not updating');
+
+nCount := nCount + 1;
+WriteCentroidValue(fbMonitor:=fbMonitor, fX:=0.5, fY:=0.5, nCount:=nCount, nX_Severity:=0, nY_Severity:=0, nCount_Severity:=0, tLastUpdate:=T#0.1S);
+fbMonitor(fMinimumValidChange:=0.1, fMaximumFrameTime:=0.2);
+AssertTrue(fbMonitor.bIsUpdating, Message:='Centroid update above threshold and is updating');
+
+TEST_FINISHED();
+
+TEST('Severity invalidation');
+
+nCount := nCount + 1;
+WriteCentroidValue(fbMonitor:=fbMonitor, fX:=0.0, fY:=0.0, nCount:=nCount, nX_Severity:=2, nY_Severity:=0, nCount_Severity:=0, tLastUpdate:=T#0.2S);
+fbMonitor(fMinimumValidChange:=0.0);
+AssertFalse(fbMonitor.bValid, Message:='Invalid data - x severity');
+
+nCount := nCount + 1;
+WriteCentroidValue(fbMonitor:=fbMonitor, fX:=0.1, fY:=0.1, nCount:=nCount, nX_Severity:=0, nY_Severity:=2, nCount_Severity:=0, tLastUpdate:=T#0.2S);
+fbMonitor(fMinimumValidChange:=0.0);
+AssertFalse(fbMonitor.bValid, Message:='Invalid data - y severity');
+
+nCount := nCount + 1;
+WriteCentroidValue(fbMonitor:=fbMonitor, fX:=0.2, fY:=0.2, nCount:=nCount, nX_Severity:=0, nY_Severity:=0, nCount_Severity:=2, tLastUpdate:=T#0.2S);
+fbMonitor(fMinimumValidChange:=0.0);
+AssertFalse(fbMonitor.bValid, Message:='Invalid data - count severity');
+
+nCount := nCount + 1;
+WriteCentroidValue(fbMonitor:=fbMonitor, fX:=0.0, fY:=0.0, nCount:=nCount, nX_Severity:=0, nY_Severity:=0, nCount_Severity:=0, tLastUpdate:=T#0.1S);
+fbMonitor(fMinimumValidChange:=0.0);
+AssertTrue(fbMonitor.bValid, Message:='Data valid');
+AssertTrue(fbMonitor.bIsUpdating, Message:='Data valid and updating');
+
+TEST_FINISHED();
+]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="WriteCentroidValue" Id="{4e3dbc52-94e8-4849-bc38-c135e919c1aa}">
+      <Declaration><![CDATA[METHOD WriteCentroidValue
+VAR_IN_OUT
+    fbMonitor : FB_EpicsCentroidMonitor;
+END_VAR
+VAR_INPUT
+    fX : LREAL;
+    fY : LREAL;
+    nCount : INT;
+    nX_Severity : INT := 0;
+    nY_Severity : INT := 0;
+    nCount_Severity : INT := 0;
+    tLastUpdate : TIME;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[WRITE_PROTECTED_INT(ADR(fbMonitor.fbCentroidX.iPLCInternalSeverity), nX_Severity);
+WRITE_PROTECTED_INT(ADR(fbMonitor.fbCentroidY.iPLCInternalSeverity), nY_Severity);
+WRITE_PROTECTED_INT(ADR(fbMonitor.fbArrayCounter.iPLCInternalSeverity), nCount_Severity);
+
+WRITE_PROTECTED_LREAL(ADR(fbMonitor.fbCentroidX.fPLCInternalValue), fX);
+WRITE_PROTECTED_LREAL(ADR(fbMonitor.fbCentroidY.fPLCInternalValue), fY);
+WRITE_PROTECTED_LREAL(ADR(fbMonitor.fbArrayCounter.fPLCInternalValue), INT_TO_LREAL(nCount));
+
+WRITE_PROTECTED_TIME(ADR(fbMonitor.tLastUpdate), TIME() - tLastUpdate);
+]]></ST>
+      </Implementation>
+    </Method>
+  </POU>
+</TcPlcObject>

--- a/LCLSGeneral/LCLSGeneral/POUs/Data/Tests/FB_Test_EpicsMotorMonitor.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Data/Tests/FB_Test_EpicsMotorMonitor.TcPOU
@@ -1,0 +1,178 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+  <POU Name="FB_Test_EpicsMotorMonitor" Id="{311bff34-9bb2-4463-9f15-81af7df4e6ba}" SpecialFunc="None">
+    <Declaration><![CDATA[{attribute 'call_after_init'}
+FUNCTION_BLOCK FB_Test_EpicsMotorMonitor EXTENDS TcUnit.FB_TestSuite
+VAR_INPUT
+END_VAR
+VAR_OUTPUT
+END_VAR
+VAR
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[TestBasics();]]></ST>
+    </Implementation>
+    <Method Name="TestBasics" Id="{874ed43f-1e5d-4a1e-82b9-ab379a271a7c}">
+      <Declaration><![CDATA[METHOD TestBasics
+VAR_INPUT
+END_VAR
+VAR_INST
+    fbMonitor : FB_EpicsMotorMonitor;
+END_VAR]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[TEST('Basic');
+
+WriteData(fbMonitor:=fbMonitor, fRBV:=0.0, nMoving:=0, nStatus:=0, nRBV_Severity:=0, nStatus_Severity:=0, nMoving_Severity:=0);
+fbMonitor();
+AssertTrue(fbMonitor.bValid, Message:='Data valid');
+
+TEST_FINISHED();
+
+
+TEST('Severities');
+
+WriteData(fbMonitor:=fbMonitor, fRBV:=0.0, nMoving:=0, nStatus:=0, nRBV_Severity:=2, nStatus_Severity:=0, nMoving_Severity:=0);
+fbMonitor();
+AssertFalse(fbMonitor.bValid, Message:='Invalid RBV');
+
+WriteData(fbMonitor:=fbMonitor, fRBV:=0.0, nMoving:=0, nStatus:=0, nRBV_Severity:=0, nStatus_Severity:=2, nMoving_Severity:=0);
+fbMonitor();
+AssertFalse(fbMonitor.bValid, Message:='Invalid status');
+
+WriteData(fbMonitor:=fbMonitor, fRBV:=0.0, nMoving:=0, nStatus:=0, nRBV_Severity:=0, nStatus_Severity:=0, nMoving_Severity:=2);
+fbMonitor();
+AssertFalse(fbMonitor.bValid, Message:='Invalid moving');
+
+WriteData(fbMonitor:=fbMonitor, fRBV:=0.0, nMoving:=0, nStatus:=0, nRBV_Severity:=0, nStatus_Severity:=0, nMoving_Severity:=0);
+fbMonitor();
+AssertTrue(fbMonitor.bValid, Message:='All valid');
+
+TEST_FINISHED();
+
+TEST('Moving');
+
+WriteData(fbMonitor:=fbMonitor, fRBV:=0.0, nMoving:=0 (* DMOV *), nStatus:=0, nRBV_Severity:=0, nStatus_Severity:=0, nMoving_Severity:=0);
+fbMonitor();
+AssertTrue(fbMonitor.bIsMoving, Message:='Moving');
+
+WriteData(fbMonitor:=fbMonitor, fRBV:=0.0, nMoving:=1 (* DMOV *), nStatus:=0, nRBV_Severity:=0, nStatus_Severity:=0, nMoving_Severity:=0);
+fbMonitor();
+AssertFalse(fbMonitor.bIsMoving, Message:='Not moving');
+
+TEST_FINISHED();
+
+TEST('Position');
+
+WriteData(fbMonitor:=fbMonitor, fRBV:=10.0, nMoving:=0, nStatus:=0, nRBV_Severity:=0, nStatus_Severity:=0, nMoving_Severity:=0);
+fbMonitor();
+AssertEquals_LREAL(Actual:=fbMonitor.fPosition, Expected:=10.0, Delta:=0.1, Message:='Position 1 OK');
+
+WriteData(fbMonitor:=fbMonitor, fRBV:=20.0, nMoving:=0, nStatus:=0, nRBV_Severity:=0, nStatus_Severity:=0, nMoving_Severity:=0);
+fbMonitor();
+AssertEquals_LREAL(Actual:=fbMonitor.fPosition, Expected:=20.0, Delta:=0.1, Message:='Position 2 OK');
+
+TEST_FINISHED();
+
+TEST('MSTA set');
+
+WriteData(fbMonitor:=fbMonitor, fRBV:=0.0, nMoving:=0, nStatus:=16#0FFFF, nRBV_Severity:=0, nStatus_Severity:=0, nMoving_Severity:=0);
+fbMonitor();
+
+AssertTrue(fbMonitor.stMSTA.bPositiveDirection, Message:='bPositiveDirection True');
+AssertTrue(fbMonitor.stMSTA.bDone, Message:='bDone True');
+AssertTrue(fbMonitor.stMSTA.bPlusLimitSwitch, Message:='bPlusLimitSwitch True');
+AssertTrue(fbMonitor.stMSTA.bHomeLimitSwitch, Message:='bHomeLimitSwitch True');
+AssertTrue(fbMonitor.stMSTA.bUnused0, Message:='bUnused0 True');
+AssertTrue(fbMonitor.stMSTA.bClosedLoop, Message:='bClosedLoop True');
+AssertTrue(fbMonitor.stMSTA.bSlipStall, Message:='bSlipStall True');
+AssertTrue(fbMonitor.stMSTA.bHome, Message:='bHome True');
+AssertTrue(fbMonitor.stMSTA.bEncoderPresent, Message:='bEncoderPresent True');
+AssertTrue(fbMonitor.stMSTA.bHardwareProblem, Message:='bHardwareProblem True');
+AssertTrue(fbMonitor.stMSTA.bMoving, Message:='bMoving True');
+AssertTrue(fbMonitor.stMSTA.bGainSupport, Message:='bGainSupport True');
+AssertTrue(fbMonitor.stMSTA.bCommError, Message:='bCommError True');
+AssertTrue(fbMonitor.stMSTA.bMinusLimitSwitch, Message:='bMinusLimitSwitch True');
+AssertTrue(fbMonitor.stMSTA.bHomed, Message:='bHomed True');
+
+TEST_FINISHED();
+
+
+TEST('MSTA zero');
+
+WriteData(fbMonitor:=fbMonitor, fRBV:=0.0, nMoving:=0, nStatus:=16#0000, nRBV_Severity:=0, nStatus_Severity:=0, nMoving_Severity:=0);
+fbMonitor();
+
+AssertFalse(fbMonitor.stMSTA.bPositiveDirection, Message:='bPositiveDirection False');
+AssertFalse(fbMonitor.stMSTA.bDone, Message:='bDone False');
+AssertFalse(fbMonitor.stMSTA.bPlusLimitSwitch, Message:='bPlusLimitSwitch False');
+AssertFalse(fbMonitor.stMSTA.bHomeLimitSwitch, Message:='bHomeLimitSwitch False');
+AssertFalse(fbMonitor.stMSTA.bUnused0, Message:='bUnused0 False');
+AssertFalse(fbMonitor.stMSTA.bClosedLoop, Message:='bClosedLoop False');
+AssertFalse(fbMonitor.stMSTA.bSlipStall, Message:='bSlipStall False');
+AssertFalse(fbMonitor.stMSTA.bHome, Message:='bHome False');
+AssertFalse(fbMonitor.stMSTA.bEncoderPresent, Message:='bEncoderPresent False');
+AssertFalse(fbMonitor.stMSTA.bHardwareProblem, Message:='bHardwareProblem False');
+AssertFalse(fbMonitor.stMSTA.bMoving, Message:='bMoving False');
+AssertFalse(fbMonitor.stMSTA.bGainSupport, Message:='bGainSupport False');
+AssertFalse(fbMonitor.stMSTA.bCommError, Message:='bCommError False');
+AssertFalse(fbMonitor.stMSTA.bMinusLimitSwitch, Message:='bMinusLimitSwitch False');
+AssertFalse(fbMonitor.stMSTA.bHomed, Message:='bHomed False');
+
+TEST_FINISHED();
+
+
+TEST('MSTA something');
+
+WriteData(fbMonitor:=fbMonitor, fRBV:=0.0, nMoving:=0, nStatus:=2#0100_0011_0000_0110, nRBV_Severity:=0, nStatus_Severity:=0, nMoving_Severity:=0);
+fbMonitor();
+
+AssertFalse(fbMonitor.stMSTA.bPositiveDirection, Message:='bPositiveDirection');
+AssertTrue(fbMonitor.stMSTA.bDone, Message:='bDone');
+AssertTrue(fbMonitor.stMSTA.bPlusLimitSwitch, Message:='bPlusLimitSwitch');
+AssertFalse(fbMonitor.stMSTA.bHomeLimitSwitch, Message:='bHomeLimitSwitch');
+
+AssertFalse(fbMonitor.stMSTA.bUnused0, Message:='bUnused0');
+AssertFalse(fbMonitor.stMSTA.bClosedLoop, Message:='bClosedLoop');
+AssertFalse(fbMonitor.stMSTA.bSlipStall, Message:='bSlipStall');
+AssertFalse(fbMonitor.stMSTA.bHome, Message:='bHome');
+
+AssertTrue(fbMonitor.stMSTA.bEncoderPresent, Message:='bEncoderPresent');
+AssertTrue(fbMonitor.stMSTA.bHardwareProblem, Message:='bHardwareProblem');
+AssertFalse(fbMonitor.stMSTA.bMoving, Message:='bMoving');
+AssertFalse(fbMonitor.stMSTA.bGainSupport, Message:='bGainSupport');
+
+AssertFalse(fbMonitor.stMSTA.bCommError, Message:='bCommError');
+AssertFalse(fbMonitor.stMSTA.bMinusLimitSwitch, Message:='bMinusLimitSwitch');
+AssertTrue(fbMonitor.stMSTA.bHomed, Message:='bHomed');
+
+TEST_FINISHED();
+]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="WriteData" Id="{4127bcaf-f066-4306-90c6-57c0f07136fb}">
+      <Declaration><![CDATA[METHOD WriteData
+VAR_IN_OUT
+    fbMonitor : FB_EpicsMotorMonitor;
+END_VAR
+VAR_INPUT
+    fRBV : LREAL;
+    nMoving : INT;
+    nStatus : UINT;
+    nRBV_Severity : INT := 0;
+    nStatus_Severity : INT := 0;
+    nMoving_Severity : INT := 0;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[WRITE_PROTECTED_INT(ADR(fbMonitor.fbRBVCheck.iPLCInternalSeverity), nRBV_Severity);
+WRITE_PROTECTED_INT(ADR(fbMonitor.fbMotorStatusCheck.iPLCInternalSeverity), nStatus_Severity);
+WRITE_PROTECTED_INT(ADR(fbMonitor.fbMovingCheck.iPLCInternalSeverity), nMoving_Severity);
+
+WRITE_PROTECTED_LREAL(ADR(fbMonitor.fbRBVCheck.fPLCInternalValue), fRBV);
+WRITE_PROTECTED_LREAL(ADR(fbMonitor.fbMotorStatusCheck.fPLCInternalValue), UINT_TO_LREAL(nStatus));
+WRITE_PROTECTED_LREAL(ADR(fbMonitor.fbMovingCheck.fPLCInternalValue), INT_TO_LREAL(nMoving));]]></ST>
+      </Implementation>
+    </Method>
+  </POU>
+</TcPlcObject>

--- a/LCLSGeneral/LCLSGeneral/POUs/RUN_TESTS.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/RUN_TESTS.TcPOU
@@ -5,6 +5,8 @@
 VAR
     CbTest    :    FB_CircuitBreaker_Test;
     fbCentroidTest : FB_Test_EpicsCentroidMonitor;
+    fbMotorTest : FB_Test_EpicsMotorMonitor;
+
 END_VAR
 ]]></Declaration>
     <Implementation>

--- a/LCLSGeneral/LCLSGeneral/POUs/RUN_TESTS.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/RUN_TESTS.TcPOU
@@ -4,6 +4,7 @@
     <Declaration><![CDATA[PROGRAM RUN_TESTS
 VAR
     CbTest    :    FB_CircuitBreaker_Test;
+    fbCentroidTest : FB_Test_EpicsCentroidMonitor;
 END_VAR
 ]]></Declaration>
     <Implementation>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Add function block to monitor EPICS motors through pytmc "link" pragmas
* Add function block to monitor EPICS AreaDetector centroid stats through pytmc "link" pragmas
* Add test suite for both

## Motivation and Context
Closes #60 

## How Has This Been Tested?
Included test suite

## Where Has This Been Documented?
Usage examples and information in function block comment description.

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive comments
- [x] Test suite passes locally
- [x] Libraries are set to ``Always Newest`` version (``Library, *``)
- [x] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``

## Test suite

```
3/9/2022 5:09:54 PM 893 ms | 'Task 3' (350): | ==========TESTS FINISHED RUNNING==========
3/9/2022 5:09:54 PM 993 ms | 'Task 3' (350): | ======================================
3/9/2022 5:09:54 PM 973 ms | 'Task 3' (350): | Failed tests: 0
3/9/2022 5:09:54 PM 953 ms | 'Task 3' (350): | Successful tests: 13
3/9/2022 5:09:54 PM 933 ms | 'Task 3' (350): | Tests: 13
3/9/2022 5:09:54 PM 913 ms | 'Task 3' (350): | Test suites: 3
```
