### PR TITLE
MNT: add user-customizable identifier "ledName" to FB_LED

### DIFF
--- a/LCLSGeneral/LCLSGeneral/POUs/Hardware/FB_LED.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Hardware/FB_LED.TcPOU
@@ -21,6 +21,12 @@
     2022-5-03 Maarten Thomas-Bosum
 *)
 VAR_INPUT
+	{attribute 'pytmc' := '
+        pv: NAME
+        io: io 
+    '}
+	ledName : STRING;
+	
 	iTermBits : UINT;
 	
 	{attribute 'pytmc' := '

--- a/LCLSGeneral/LCLSGeneral/POUs/Hardware/FB_LED.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Hardware/FB_LED.TcPOU
@@ -24,6 +24,8 @@ VAR_INPUT
 	{attribute 'pytmc' := '
         pv: NAME
         io: io 
+		field: DESC Descriptive name for the LED
+        autosave_pass0: VAL DESC
     '}
 	ledName : STRING;
 	


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Added a String Pragma as a VAR_INPUT to the FB_LED.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I would like for there to be a description PV which will show up on the typhos screen, which will be user editable so users can label their LEDs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I have not been able to test this anywhere.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive comments
- [ ] Test suite passes locally
- [x] Libraries are set to ``Always Newest`` version (``Library, *``)
- [ ] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
