### PR TITLE
FIX: compile with EPS

### DIFF
--- a/LCLSGeneral/LCLSGeneral/LCLSGeneral.plcproj
+++ b/LCLSGeneral/LCLSGeneral/LCLSGeneral.plcproj
@@ -33,6 +33,7 @@
     <Folder Include="Data types\Misc" />
     <Folder Include="Data types\EPICS" />
     <Folder Include="GVLs" />
+    <Folder Include="DUTs" />
     <Folder Include="POUs" />
     <Folder Include="POUs\Data\Tests" />
     <Folder Include="POUs\Diagnostics\DUT" />
@@ -43,6 +44,7 @@
     <Folder Include="POUs\Hardware" />
     <Folder Include="POUs\Diagnostics" />
     <Folder Include="POUs\Logger\Tests" />
+    <Folder Include="POUs\EPS" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Data types\EPICS\ST_EpicsMotorMSTA.TcDUT">
@@ -55,6 +57,9 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Data types\Misc\ST_System.TcDUT">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="DUTs\DUT_EPS.TcDUT">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="GVLs\GeneralConstants.TcGVL">
@@ -132,6 +137,9 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="POUs\Diagnostics\FB_EtherCATFrameDiag.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="POUs\EPS\FB_EPS.TcPOU">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="POUs\Functions\FB_EcatDiag.TcPOU">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Make the twincat general lib compile with the EPS DUT and FB from #67 included.
The files were previously added without including them in the solution, this was missed in review.
As a result, the newest tag doesn't actually work to include the EPS elements.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
These are needed to make the newest motion lib with first-class EPS support work.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I built the library and verified that the result has the EPS elements.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Release notes only

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive comments
- [ ] Test suite passes locally
- [x] Libraries are set to ``Always Newest`` version (``Library, *``)
- [ ] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
