### PR TITLE
ENH: allow user projects to configure the number of allowed states

### DIFF
--- a/LCLSGeneral/LCLSGeneral/GVLs/GeneralConstants.TcGVL
+++ b/LCLSGeneral/LCLSGeneral/GVLs/GeneralConstants.TcGVL
@@ -1,10 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
-  <GVL Name="GeneralConstants" Id="{57f2f1ff-0c58-4e70-a147-fb0d6c2bb252}">
+  <GVL Name="GeneralConstants" Id="{5fbde5e2-29c8-4193-ba17-69759df29f93}" ParameterList="True">
     <Declaration><![CDATA[{attribute 'qualified_only'}
 VAR_GLOBAL CONSTANT
-    // 16 including "Unknown" is the max for an EPICS MBBI
+    // 16 including "Unknown" is the max for an EPICS MBBI/MBBO
     // This is the max number of user-defined states (OUT, TARGET1, YAG...)
+    // You can make this smaller if you want to use less memory in your program in exchange for limiting your max state count
+    // You can make this larger if you want to use states-based FBs sized beyond the EPICS enum limit
     MAX_STATES: INT := 15;
 END_VAR
 ]]></Declaration>

--- a/LCLSGeneral/LCLSGeneral/LCLSGeneral.plcproj
+++ b/LCLSGeneral/LCLSGeneral/LCLSGeneral.plcproj
@@ -62,16 +62,16 @@
     <Compile Include="DUTs\DUT_EPS.TcDUT">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="GVLs\GeneralConstants.TcGVL">
-      <SubType>Code</SubType>
-      <LinkAlways>true</LinkAlways>
-    </Compile>
     <Compile Include="GVLs\DefaultGlobals.TcGVL">
       <SubType>Code</SubType>
       <LinkAlways>true</LinkAlways>
     </Compile>
     <Compile Include="GVLs\Global_Variables_EtherCAT.TcGVL">
       <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="GVLs\GeneralConstants.TcGVL">
+      <SubType>Code</SubType>
+      <LinkAlways>true</LinkAlways>
     </Compile>
     <Compile Include="POUs\Data\FB_BasicStats.TcPOU">
       <SubType>Code</SubType>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Replace the `GeneralConstants` GVL with a parameter list, allowing us to configure `GeneralConstants.MAX_STATES` on a per-plc basis.

See https://infosys.beckhoff.com/english.php?content=../content/1033/tc3_plc_intro/3470837515.html&id=

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If you create a GVL as a parameter list, then individual projects are allowed to change the value for the context of that project. There are two reasons to want to change this particular value:
- Decrease the number of states allocated in states FBs to reduce the memory footprint of the project and of the generated PVs
- Increase the number of states allocated in states FBs to allow for many-many state devices.

Other constants in the future may also be useful to configure on a per-project basis.

In this specific case, I'm doing this now because TMO has threatened to need a 17 state device, which is greater than the sensible default here of "match the EPICS MBBI/MBBO behavior". Once realized, this device will not be able to use an MBBI/MBBO for the setter/getter, but we'll still do our best to support it...

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I haven't tested this at all. Before merging, I'll check how this behaves in a few projects.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
n/a

## Pre-merge checklist
- [ ] Code works interactively
- [x] Code contains descriptive comments
- [ ] Test suite passes locally
- [x] Libraries are set to ``Always Newest`` version (``Library, *``)
- [x] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
