### PR TITLE
MAINT: remove manual license selection tcp/ip

### DIFF
--- a/LCLSGeneral/LCLSGeneral.tsproj
+++ b/LCLSGeneral/LCLSGeneral.tsproj
@@ -281,11 +281,6 @@
 	</DataTypes>
 	<Project ProjectGUID="{9AC02CD1-4FA4-49DE-BC09-848126C612E3}" TargetNetId="172.21.148.145.1.1" ShowHideConfigurations="#x3c7">
 		<System>
-			<Licenses>
-				<Target>
-					<ManualSelect>{3EBB9639-5FF3-42B6-8847-35C70DC013C8}</ManualSelect>
-				</Target>
-			</Licenses>
 			<Tasks>
 				<Task Id="3" Priority="1" CycleTime="100000" AmsPort="350" AdtTasks="true">
 					<Name>Task 3</Name>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
The library project here has a manual license selection added for tcp/ip
This is actually only needed for component PLCs using this library and is not required for the unit tests
In this PR I remove the manual selection so that the library project can run through its unit tests with the current licenses installed on the ci PLC

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This might be why the CI stalled out two weeks ago

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
N/A

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive comments
- [x] Test suite passes locally
- [x] Libraries are set to ``Always Newest`` version (``Library, *``)
- [x] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
