### PR TITLE
Fixed incorrect casing in LCLSGeneral.plcproj

### DIFF
--- a/LCLSGeneral/LCLSGeneral/LCLSGeneral.plcproj
+++ b/LCLSGeneral/LCLSGeneral/LCLSGeneral.plcproj
@@ -54,7 +54,7 @@
     <Compile Include="Data types\Misc\ST_EcDevice.TcDUT">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="Data types\Misc\ST_FbDiagnostics.TcDUT">
+    <Compile Include="Data types\Misc\ST_fbDiagnostics.TcDUT">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Data types\Misc\ST_System.TcDUT">
@@ -95,7 +95,7 @@
     <Compile Include="POUs\Data\FB_STRINGFromEPICS.TcPOU">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="POUs\Data\FB_TimeStampBuffer.TcPOU">
+    <Compile Include="POUs\Data\FB_TimestampBuffer.TcPOU">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="POUs\Data\FB_TimeStampBufferGlobal.TcPOU">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

Silly of course: but the names of two files in the PLC project don't match.

On Windows this should almost never be relevant, but I thought maybe you'll accept this fix.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I ran into this as I'm using this project as a test target for a Sphinx-PLC integration.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to ``Always Newest`` version (``Library, *``)
- [ ] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
