### PR TITLE
FIX: typos that make one pragma get skipped by pytmc

### DIFF
--- a/LCLSGeneral/LCLSGeneral/DUTs/DUT_EPS.TcDUT
+++ b/LCLSGeneral/LCLSGeneral/DUTs/DUT_EPS.TcDUT
@@ -28,10 +28,10 @@ STRUCT
     sMessage: STRING;
 
     // Keep Track if nFlags are all true
-    {atribute 'pytmc' := '
+    {attribute 'pytmc' := '
         pv: bEPS_OK
         io: i
-        field: DESC check if nFlags are all true;
+        field: DESC check if nFlags are all true
     '}
     bEPS_OK : BOOL := TRUE;
 END_STRUCT


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
`atribute`-> `attribute`
remove `;`
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This one EPS PV isn't being built in any of our IOCs because it's not a proper pytmc attribute.
`attribute` is misspelled and the `;` can not/should not be included here.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively with my open example motion PR

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Just this PR and the link to this PR that I'll put in the release notes.

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive comments
- [x] Test suite passes locally
- [x] Libraries are set to ``Always Newest`` version (``Library, *``)
- [x] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
