### PR TITLE
ENH: add rms calc

### DIFF
--- a/LCLSGeneral/LCLSGeneral/POUs/Data/FB_BasicStats.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Data/FB_BasicStats.TcPOU
@@ -111,7 +111,7 @@ ELSIF bAlwaysCalc OR rTrig.Q THEN
     FOR nIndex := LOWER_BOUND(aSignal, 1) TO UPPER_BOUND(aSignal, 1) DO
         nElemsSeen := nElemsSeen + 1;
         fSum := fSum + aSignal[nIndex];
-        fRMSSum := EXPT(aSignal[nIndex], 2);
+        fRMSSum := fRMSSum + EXPT(aSignal[nIndex], 2);
         IF aSignal[nIndex] > fMax THEN
             fMax := aSignal[nIndex];
         ELSIF aSignal[nIndex] < fMin tHEN

--- a/LCLSGeneral/LCLSGeneral/POUs/Data/FB_BasicStats.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Data/FB_BasicStats.TcPOU
@@ -97,6 +97,7 @@ IF bReset THEN
     fMax := 0;
     fMin := 0;
     fRange := 0;
+    fRMS := 0;
     bValid := FALSE;
     bReset := FALSE;
 ELSIF NOT (bExecute OR bAlwaysCalc) THEN

--- a/LCLSGeneral/LCLSGeneral/POUs/Data/FB_BasicStats.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Data/FB_BasicStats.TcPOU
@@ -102,7 +102,7 @@ IF bReset THEN
 ELSIF NOT (bExecute OR bAlwaysCalc) THEN
     bValid := FALSE;
 ELSIF bAlwaysCalc OR rTrig.Q THEN
-    // First pass through aSignal: get sum, mean, max, min
+    // First pass through aSignal: get sum, mean, max, min, rms
     nElemsSeen := 0;
     fSum := 0;
     fRMSSum := 0;

--- a/LCLSGeneral/LCLSGeneral/POUs/Data/FB_BasicStats.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Data/FB_BasicStats.TcPOU
@@ -66,6 +66,12 @@ VAR_OUTPUT
         io: i
     '}
     fRange: LREAL;
+    // RMS of all values in the array
+    {attribute 'pytmc' := '
+        pv: STATS:RMS
+        io: i
+    '}
+    fRMS: LREAL;
     // True if the other outputs are valid
     {attribute 'pytmc' := '
         pv: STATS:VALID
@@ -78,6 +84,7 @@ VAR
     nIndex: DINT;
     nElemsSeen: UDINT;
     fSum: LREAL;
+    fRMSSum: LREAL;
     fVarianceSum: LREAL;
     fVarianceMean: LREAL;
 END_VAR
@@ -98,11 +105,13 @@ ELSIF bAlwaysCalc OR rTrig.Q THEN
     // First pass through aSignal: get sum, mean, max, min
     nElemsSeen := 0;
     fSum := 0;
+    fRMSSum := 0;
     fMax := aSignal[LOWER_BOUND(aSignal, 1)];
     fMin := fMax;
     FOR nIndex := LOWER_BOUND(aSignal, 1) TO UPPER_BOUND(aSignal, 1) DO
         nElemsSeen := nElemsSeen + 1;
         fSum := fSum + aSignal[nIndex];
+        fRMSSum := EXPT(aSignal[nIndex], 2);
         IF aSignal[nIndex] > fMax THEN
             fMax := aSignal[nIndex];
         ELSIF aSignal[nIndex] < fMin tHEN
@@ -115,6 +124,7 @@ ELSIF bAlwaysCalc OR rTrig.Q THEN
     IF nElemsSeen > 0 THEN
         fMean := fSum / nElemsSeen;
         fRange := fMax - fMin;
+        fRMS := SQRT(fRMSSum / nElemsSeen);
 
         // Second pass through aSignal: get the sum of the variances and then the stdev
         nElemsSeen := 0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- added `fRMS` to `FB_BasicStats`
- added supporting logic to calculate `fRMS`


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- SP1K1 RIX monochromator grating pitch RMS is out of spec, adding a real time variable for RMS to monitor.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Ran a dev version of `LCLS General` on `lcls-plc-rixs-optics` check RMS calculation as expected:
![image](https://github.com/pcdshub/lcls-twincat-general/assets/79480290/2d1bee17-c2e9-4a6a-bfec-50d9965c4579)


## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
- https://jira.slac.stanford.edu/browse/ECS-1534

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive comments
- [x] Test suite passes locally
- [x] Libraries are set to ``Always Newest`` version (``Library, *``)
- [x] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
