### PR TITLE
Using DINT instead of INT in FB_AnalogInput

### DIFF
--- a/LCLSGeneral/LCLSGeneral/POUs/Hardware/FB_AnalogInput.TcPOU
+++ b/LCLSGeneral/LCLSGeneral/POUs/Hardware/FB_AnalogInput.TcPOU
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
   <POU Name="FB_AnalogInput" Id="{c3bf2f11-e399-406d-ba95-ae8960e90a27}" SpecialFunc="None">
     <Declaration><![CDATA[FUNCTION_BLOCK FB_AnalogInput
 (*
@@ -8,7 +8,7 @@
 *)
 VAR_INPUT
     // Connect this input to the terminal
-    iRaw AT %I*: INT;
+    iRaw AT %I*: DINT;
     // The number of bits correlated with the terminal's max value. This is not necessarily the resolution parameter.
     iTermBits: UINT;
     // The fReal value correlated with the terminal's max value


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
The input variable of FB_AnalogInput, iRaw, has its  type changed from INT (16bit) to DINT (32bit). My idea is that this will allow it to handle 32bit inputs, while 16bit inputs like which are currently being used will be implicitly upcasted with no noticeable change for all the places the currently use FB_AnalogInput. 

Page that (briefly) mentions implicit casting from smaller to larger types
https://infosys.beckhoff.com/english.php?content=../content/1033/tc3_plc_intro/3998090635.html&id=

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The IM4K2 uses a high resolution adc whose output has a 32 bit representation. Since FB_AnalogInput has an input of 16bits, an almost exact copy of FB_PPM, FB_PPM_PowerMeter, and FB_AnalogInput was made to support 32 bit conversions.  We are going to install another high resolution adc in rix next week, and in the future we will probably install many more around lcls so it would be nice if this function block was updated to support that. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I think all the test plcs are down while the first floor is being renovated, but if this is wrong please let me know what machine I can run the unit tests on. 

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
I think this is small enough that it doesn't need a comment. 

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to ``Always Newest`` version (``Library, *``)
- [ ] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
